### PR TITLE
Centralize graphql queries with sendtosser

### DIFF
--- a/src/lib/components/lev/decisionMaking.svelte
+++ b/src/lib/components/lev/decisionMaking.svelte
@@ -276,18 +276,15 @@ async function agree() {
             }
               `
                try {
-      let res4 = await SendTo(que4, VITE_ADMINMONTHER).then((res4) => (res4 = res4));
-      console.log(res4,"ask res4 ")      
-      if (res4.data != null) {
-              console.log(res4.data,"ask res4 ")      
- dispatch('acsept', {
-                ani: "askedma",
-                coinlapach: coinlapach 
-            })
+                 const res4 = await sendToSer({ id: timegramaId, done: true }, '35updateTimeGrama', null, null, true, fetch);
+                 console.log(res4, "ask res4 ");
+                 if (res4.data != null) {
+                   console.log(res4.data, "ask res4 ");
+                   dispatch('acsept', { ani: "askedma", coinlapach: coinlapach });
+                 }
+               } catch (e) {
+                 console.error(e);
                }
- } catch (e) {
-      console.error(e);
-    }
   }
 
         } catch (e) {
@@ -405,7 +402,7 @@ function hoverc (event){
     dispatch("hover", {id: u[$lang]});
 }
  import Card from './cards/hachlata.svelte'
-  import {SendTo} from '$lib/send/sendTo.svelte';
+  import { sendToSer } from '$lib/send/sendToSer.js';
 export let cards = false;
 export let tx = 200;
 const newlogo = {"he":"הלוגו החדש שמוצע","en":"new Logo offered"}

--- a/src/lib/components/lev/missionInProgress.svelte
+++ b/src/lib/components/lev/missionInProgress.svelte
@@ -790,80 +790,44 @@ function claf (event){
       console.log(t,"rfweiofjw",op)
     }
     async function taskishor(id){
-      console.log(id)
-      let que = `mutation { 
-  updateAct(
-      id: ${id}
-      data: { 
-        myIshur: true
- }
-  ){data {id}}
- } ` 
-    console.log(que)
- try{
- let res = await SendTo(que)
- .then (res => res = res);
-  console.log(res)
-  if(res.data !=null){
-    toast.success(suc[$lang])
-  }else{
-    toast.warning(er[$lang])
-  }
-}  catch (e) {
-  console.error(e)
-  toast.warning(`${er[$lang]}`,{description: e.status+ ": "+e.message})
-  }
+      try {
+        const res = await sendToSer({ id, myIshur: true }, '61ApproveAct', null, null, false, fetch);
+        if (res.data?.updateAct?.data) {
+          toast.success(suc[$lang]);
+        } else {
+          toast.warning(er[$lang]);
+        }
+      } catch (e) {
+        console.error(e);
+        toast.warning(`${er[$lang]}`, { description: e.status + ": " + e.message });
+      }
     }
-async function busabe(id){
-      console.log(id)
-      let que = `mutation { 
-  updateAct(
-      id: ${id}
-      data: { 
-        naasa: true
- }
-  ){data {id}}
- } ` 
-    console.log(que)
- try{
- let res = await SendTo(que)
- .then (res => res = res);
-  console.log(res)
-  if(res.data !=null){
-    toast.success(suc[$lang])
-  }else{
-    toast.warning(er[$lang])
-  }
-}  catch (e) {
-  console.error(e)
-  toast.warning(`${er[$lang]}`,{description: e.status+ ": "+e.message})
-  }
+    async function busabe(id){
+      try {
+        const res = await sendToSer({ id, naasa: true }, '62MarkActDone', null, null, false, fetch);
+        if (res.data?.updateAct?.data) {
+          toast.success(suc[$lang]);
+        } else {
+          toast.warning(er[$lang]);
+        }
+      } catch (e) {
+        console.error(e);
+        toast.warning(`${er[$lang]}`, { description: e.status + ": " + e.message });
+      }
     }
     async function updStat(id,st,i){
-      console.log(id)
-      let que = `mutation { 
-  updateAct(
-      id: ${id}
-      data: { 
-        status: ${st}
- }
-  ){data {id}}
- } ` 
-    console.log(que)
- try{
- let res = await SendTo(que)
- .then (res => res = res);
-  console.log(res)
-  if(res.data !=null){
-    toast.success(suc[$lang])
-    op[i] = false
-  }else{
-    toast.warning(er[$lang])
-  }
-}  catch (e) {
-  console.error(e)
-  toast.warning(`${er[$lang]}`,{description: e.status+ ": "+e.message})
-  }
+      try {
+        const res = await sendToSer({ id, status: st }, '63SetActStatus', null, null, false, fetch);
+        if (res.data?.updateAct?.data) {
+          toast.success(suc[$lang]);
+          op[i] = false;
+        } else {
+          toast.warning(er[$lang]);
+        }
+      } catch (e) {
+        console.error(e);
+        toast.warning(`${er[$lang]}`, { description: e.status + ": " + e.message });
+      }
     }
   let a = 1;
   const suc = {"he": "בוצע בהצלחה","en":"appruved sucssefully!"}

--- a/src/routes/api/send/qids.js
+++ b/src/routes/api/send/qids.js
@@ -519,4 +519,157 @@ export const qids = {
   }
  }
 `,
+  '39OpenMissionById': `query OpenMissionById($mId: ID!) {
+    openMission(id: $mId) {
+      data {
+        id
+        attributes {
+          sqadualed
+          archived
+          acts { data { attributes { shem } } }
+          users { data { id } }
+          project {
+            data {
+              id
+              attributes {
+                projectName
+                user_1s { data { id } }
+                restime
+                timeToP
+                profilePic { data { attributes { url } } }
+              }
+            }
+          }
+          tafkidims { data { attributes { roleDescription localizations { data { attributes { roleDescription } } } } } }
+          skills { data { attributes { skillName localizations { data { attributes { skillName } } } } } }
+          descrip
+          hearotMeyuchadot
+          name
+          dates
+          iskvua
+          work_ways { data { attributes { workWayName localizations { data { attributes { workWayName } } } } } }
+          noofhours
+          perhour
+        }
+      }
+    }
+  }`,
+  '40OpenMashaabimById': `query OpenMashaabimById($mId: ID!) {
+    openMashaabim(id: $mId) {
+      data {
+        id
+        attributes {
+          archived
+          price
+          descrip
+          spnot
+          kindOf
+          sqadualedf
+          sqadualed
+          linkto
+          createdAt
+          hm
+          name
+          easy
+          declinedsps { data { id } }
+          users { data { id } }
+          mashaabim { data { id } }
+          project {
+            data {
+              id
+              attributes {
+                restime
+                projectName
+                user_1s { data { id } }
+                timeToP
+                profilePic { data { attributes { url } } }
+              }
+            }
+          }
+        }
+      }
+    }
+  }`,
+  '41ProjectById': `query ProjectById($pid: ID!) {
+    project(id: $pid) {
+      data {
+        id
+        attributes {
+          projectName
+          user_1s { data { id attributes { username profilePic { data { attributes { url } } } } } }
+          linkToWebsite
+          restime
+          sheiruts(filters: { isApruved: { eq: true } }) { data { id attributes { name descrip equaliSplited oneTime isApruved } } }
+          githublink
+          fblink
+          discordlink
+          twiterlink
+          vallues { data { attributes { valueName localizations { data { attributes { valueName } } } } } }
+          publicDescription
+          profilePic { data { attributes { url formats } } }
+          open_missions(filters: { archived: { eq: false } }) { data { id attributes { name } } }
+        }
+      }
+    }
+  }`,
+  '42MatanotById': `query MatanotById($id: ID!) {
+    matanot(id: $id) {
+      data {
+        id
+        attributes {
+          name
+          pic { data { attributes { url } } }
+          price
+          quant
+          kindOf
+          desc
+          publishedAt
+          archived
+          startDate
+          finnishDate
+          projectcreates { data { id attributes { projectName user_1s { data { id } } restime timeToP profilePic { data { attributes { url } } } open_missions { data { id attributes { sqadualed archived tafkidims { data { attributes { roleDescription localizations { data { attributes { roleDescription } } } } } } skills { data { attributes { skillName localizations { data { attributes { skillName } } } } } } descrip hearotMeyuchadot name dates iskvua work_ways { data { attributes { workWayName localizations { data { attributes { workWayName } } } } } } noofhours perhour } } } } } }
+        }
+      }
+    }
+  }`,
+  '43UserById': `query UserById($uid: ID!) {
+    usersPermissionsUser(id: $uid) {
+      data {
+        id
+        attributes {
+          fblink
+          twiterlink
+          discordlink
+          githublink
+          bio
+          username
+          finnished_missions { data { attributes { missionName } } }
+          profilePic { data { attributes { url formats } } }
+          projects_1s { data { id attributes { projectName } } }
+          sps(filters: { archived: { eq: false } }) { data { id attributes { name panui } } }
+          skills { data { id attributes { skillName localizations { data { attributes { skillName } } } } } }
+          tafkidims { data { id attributes { roleDescription localizations { data { attributes { roleDescription } } } } } }
+          vallues { data { id attributes { valueName localizations { data { attributes { valueName } } } } } }
+          work_ways { data { id attributes { workWayName localizations { data { attributes { workWayName } } } } } }
+        }
+      }
+    }
+  }`,
+  '61ApproveAct': `mutation ApproveAct($id: ID!, $myIshur: Boolean) {
+    updateAct(id: $id, data: { myIshur: $myIshur }) { data { id } }
+  }`,
+  '62MarkActDone': `mutation MarkActDone($id: ID!, $naasa: Boolean) {
+    updateAct(id: $id, data: { naasa: $naasa }) { data { id } }
+  }`,
+  '63SetActStatus': `mutation SetActStatus($id: ID!, $status: Int) {
+    updateAct(id: $id, data: { status: $status }) { data { id } }
+  }`,
+  '44UpdateUserAskeds': `mutation UpdateUserAskeds($uid: ID!, $askeds: [ID]) {
+    updateUsersPermissionsUser(id: $uid, data: { askeds: $askeds }) { data { id } }
+  }`,
+  '45CreateAsk': `mutation CreateAsk($open_mission: ID!, $project: ID!, $users_permissions_user: ID!, $publishedAt: DateTime) {
+    createAsk(data: { open_mission: $open_mission, project: $project, users_permissions_user: $users_permissions_user, publishedAt: $publishedAt }) {
+      data { id }
+    }
+  }`,
 }

--- a/src/routes/availableMission/[id]/+page.server.js
+++ b/src/routes/availableMission/[id]/+page.server.js
@@ -1,90 +1,7 @@
-import { SendTo } from '$lib/send/sendTo.svelte';
+import { sendToSer } from '$lib/send/sendToSer.js';
 import { langAdjast } from '$lib/func/langAdjast.svelte';
 
-async function awaitapi(mId,lang,tok) {
-  let que, toc
-    if (tok != false) {
-      que = `{  openMission (id:${mId}) {data{attributes{ sqadualed
-      archived
-            acts{data{attributes{shem}}}
-
-      users{data{id}}
-project {data{ id attributes{ projectName user_1s{data{id}} restime timeToP profilePic {data{ attributes{url  }}}}}}
-     tafkidims {data{attributes{roleDescription ${
-       lang == 'he'
-         ? 'localizations{data{attributes{ roleDescription }}}'
-         : ''
-     }}}}
-     skills {data{attributes{skillName ${
-       lang == 'he' ? 'localizations{data{attributes{skillName }}}' : ''
-     }}}}
-     descrip
-     hearotMeyuchadot
-     name dates iskvua
-     work_ways {data{attributes{workWayName ${
-       lang == 'he'
-         ? 'localizations{data{attributes{workWayName }}}'
-         : ''
-     }}}}
-     noofhours perhour   }}}
- }`;
-toc = tok;
-} else {
-que = `{  openMission (id:${mId}) {data{attributes{ sqadualed
-      archived
-      acts{data{attributes{shem}}}
-      users{data{id}}
-project {data{ id attributes{ projectName user_1s{data{id}} restime timeToP profilePic {data{ attributes{url  }}}}}}
-     tafkidims {data{attributes{roleDescription ${
-       lang == 'he'
-         ? 'localizations{data{attributes{ roleDescription }}}'
-         : ''
-     }}}}
-     skills {data{attributes{skillName ${
-       lang == 'he' ? 'localizations{data{attributes{skillName }}}' : ''
-     }}}}
-     descrip
-     hearotMeyuchadot
-     name dates iskvua
-     work_ways {data{attributes{workWayName ${
-       lang == 'he'
-         ? 'localizations{data{attributes{workWayName }}}'
-         : ''
-     }}}}
-     noofhours perhour   }}}
- }`;
-    toc = import.meta.env.VITE_ADMINMONTHER;
-  }
- let alld = []
- await SendTo(que, toc)
-      .then((data) => {
-        console.log(data);
-        if (data.data.openMission.data != null) {
-          let datar = data.data.openMission.data;
-          const langd = langAdjast(datar, lang);
-          datar = langd;
-          console.log(datar);
-          alld = datar;
-          alld = alld;
-          alld.title = {
-            he: `1💗1 | הצעה למשימה "${alld.attributes.name}" בריקמה: ${alld.attributes.project.data.attributes.projectName}`,
-            en: `1💗1 | come see this mission "${alld.attributes.name}" on freeMates:"${alld.attributes.project.data.attributes.projectName}"`
-          };
-
-        } else {
-          data = null;
-                      data.fullfild = true;
-                      console.log(fullfild);
-        }
-        return alld;
-      })
-      .catch((error) => {
-        console.log(error);
-        alld = error;
-      });
-  return alld
-}
-export async function load({ locals, params }) {
+export async function load({ locals, params, fetch }) {
   const mId = params.id;
   const lang = locals.lang;
   const tok = locals.tok;
@@ -94,12 +11,25 @@ export async function load({ locals, params }) {
   let error;
   let bdata = []
   let fullfild = false
-  let toc;
   let archived = false
-  if (tok != false) {
-    toc = tok;
-  } else {
-    toc = import.meta.env.VITE_ADMINMONTHER;
+  const isSer = tok === false
+  try {
+    const res = await sendToSer({ mId }, '39OpenMissionById', null, null, isSer, fetch);
+    if (res?.data?.openMission?.data) {
+      let datar = res.data.openMission.data;
+      datar = langAdjast(datar, lang);
+      alld = datar;
+      alld.title = {
+        he: `1💗1 | הצעה למשימה "${alld.attributes.name}" בריקמה: ${alld.attributes.project.data.attributes.projectName}`,
+        en: `1💗1 | come see this mission "${alld.attributes.name}" on freeMates:"${alld.attributes.project.data.attributes.projectName}"`
+      };
+    } else {
+      alld = null;
+      fullfild = true;
+    }
+  } catch (e) {
+    console.log(e);
+    alld = e;
   }
   
   return {
@@ -107,7 +37,7 @@ export async function load({ locals, params }) {
     lang,
     mId,
     tok: tok == false ? false : true,
-      alld: await awaitapi(mId,lang,toc),
+      alld,
       fullfild
   };
 }

--- a/src/routes/availiableResorce/[id]/+page.server.js
+++ b/src/routes/availiableResorce/[id]/+page.server.js
@@ -1,69 +1,37 @@
-import { SendTo } from '$lib/send/sendTo.svelte';
+import { sendToSer } from '$lib/send/sendToSer.js';
 
-async function awaitapi(que,toc,lang) {  
- let alld = []
- await SendTo(que, toc)
-      .then((data) => {
-        console.log(data);
-         if (data.data.openMashaabim.data != null) {
-          const datar = data.data.openMashaabim.data.attributes;
-          console.log(datar);
-          if (datar.archived != true) {
-            data = datar
-            data.archived = false;
-            data.title = {
-              he: `1💗1 | הצעה לשיתוף משאב 
-              "${data.name}" 
-              בריקמה: 
-              ${data.project.data.attributes.projectName}`,
-              en: 'come see this proposal on    '
-            };
-            data.fullfild = true;
-            alld = data
-        } else {
-          data = {title: {he: '1💗1 |  הצעה לשיתוף משאב שאיננה זמינה', en: 'not relevant old proposal'}, archived: true};
-                      alld = data;
-        }
-      } else {
-        data = {title: {he: '1💗1 |  הצעה לשיתוף משאב שאיננה זמינה', en: 'not relevant old proposal'}, archived: true};
-        alld = data;
-      }
-        return alld;
-      })
-      .catch((error) => {
-        console.log(error);
-        alld = error;
-      });
-  return alld
-}
-export async function load({ locals, params }) {
+export async function load({ locals, params, fetch }) {
   const mId = params.id;
   const lang = locals.lang;
   const tok = locals.tok;
   const uid = locals.uid;
-  let que = `{ openMashaabim (id:${mId}) { data {id attributes{ archived price descrip spnot kindOf
-  sqadualedf sqadualed linkto createdAt hm name easy 
-  declinedsps {data{ id }} 
-  users {data{ id }} 
-  mashaabim{data{id}}
-  project {data{ id attributes{ restime projectName user_1s{data{id}} 
-      restime timeToP profilePic {data{ attributes{url  }}}
-    }}}
-}}}
-  }`;
   let alld;
   let error;
   let bdata = [];
   let fullfild = false;
-  let toc;
   let archived = false;
-  if (tok != false) {
-    toc = tok;
-    console.log("loged in")
-  } else {
-    toc = import.meta.env.VITE_ADMINMONTHER;
-        console.log('not loged in');
-
+  const isSer = tok === false;
+  try {
+    const res = await sendToSer({ mId }, '40OpenMashaabimById', null, null, isSer, fetch);
+    const data = res?.data?.openMashaabim?.data?.attributes;
+    if (data) {
+      if (data.archived !== true) {
+        data.archived = false;
+        data.title = {
+          he: `1💗1 | הצעה לשיתוף משאב \n              "${data.name}" \n              בריקמה: \n              ${data.project.data.attributes.projectName}`,
+          en: 'come see this proposal on    '
+        };
+        data.fullfild = true;
+        alld = data;
+      } else {
+        alld = { title: { he: '1💗1 |  הצעה לשיתוף משאב שאיננה זמינה', en: 'not relevant old proposal' }, archived: true };
+      }
+    } else {
+      alld = { title: { he: '1💗1 |  הצעה לשיתוף משאב שאיננה זמינה', en: 'not relevant old proposal' }, archived: true };
+    }
+  } catch (e) {
+    console.log(e);
+    alld = e;
   }
   
   return {
@@ -71,7 +39,7 @@ export async function load({ locals, params }) {
     lang,
     mId,
     tok: tok == false ? false : true,
-      alld: await awaitapi(que,toc,lang),
+      alld,
       fullfild
   };
 }

--- a/src/routes/project/[id]/+page.server.js
+++ b/src/routes/project/[id]/+page.server.js
@@ -1,153 +1,12 @@
-import { SendTo } from '$lib/send/sendTo.svelte';
+import { sendToSer } from '$lib/send/sendToSer.js';
 
 async function awaitapi(projectId, lang, tok) {
-  let que, toc;
-  if (tok != false) {
-    que = `{
-      project (id:${projectId}) {
-        data {
-          attributes {
-            projectName
-            user_1s {
-              data {
-                id
-                attributes {
-                  username
-                  profilePic {
-                    data {
-                      attributes {
-                        url
-                      }
-                    }
-                  }
-                }
-              }
-            }
-            linkToWebsite
-            restime
-            sheiruts(filters:{isApruved:{eq: true} }){
-              data {
-                id
-                attributes {
-                  name
-                  descrip
-                  equaliSplited
-                  oneTime
-                  isApruved
-                }
-              }
-            }
-            githublink
-            fblink
-            discordlink
-            twiterlink
-            vallues {
-              data {
-                attributes {
-                  valueName ${lang == 'he' ? 'localizations{data{attributes{ valueName }}}' : ''}
-                }
-              }
-            }
-            publicDescription
-            profilePic {
-              data {
-                attributes {
-                  url
-                  formats
-                }
-              }
-            }
-            open_missions (filters:{archived:{eq: false} }) {
-              data {
-                id
-                attributes {
-                  name
-                }
-              }
-            }
-          }
-        }
-      }
-    }`;
-    toc = tok;
-  } else {
-    // For unauthenticated users, fetch only public data
-    que = `{
-      project (id:${projectId}) {
-        data {
-          attributes {
-            projectName
-            user_1s {
-              data {
-                id
-                attributes {
-                  username
-                  profilePic {
-                    data {
-                      attributes {
-                        url
-                      }
-                    }
-                  }
-                }
-              }
-            }
-            linkToWebsite
-            sheiruts(filters:{isApruved:{eq: true} }){
-              data {
-                id
-                attributes {
-                  name
-                  descrip
-                  equaliSplited
-                  oneTime
-                  isApruved
-                }
-              }
-            }
-            githublink
-            fblink
-            discordlink
-            twiterlink
-            vallues {
-              data {
-                attributes {
-                  valueName ${lang == 'he' ? 'localizations{data{attributes{ valueName }}}' : ''}
-                }
-              }
-            }
-            publicDescription
-            profilePic {
-              data {
-                attributes {
-                  url
-                  formats
-                }
-              }
-            }
-            open_missions (filters:{archived:{eq: false} }) {
-              data {
-                id
-                attributes {
-                  name
-                }
-              }
-            }
-          }
-        }
-      }
-    }`;
-    toc = import.meta.env.VITE_ADMINMONTHER; // Use admin token for public access
-  }
-
   let projectData = null;
   try {
-    console.log("TRAYIOs")
-    const data = await SendTo(que, toc);
-    console.log(data)
-    if (data.data.project.data != null) {
+    const isSer = tok === false;
+    const data = await sendToSer({ pid: projectId }, '41ProjectById', null, null, isSer, fetch);
+    if (data?.data?.project?.data) {
       projectData = data.data.project.data;
-      console.log(projectData)
     }
   } catch (error) {
     console.error("Error fetching project data:", error);
@@ -156,7 +15,7 @@ async function awaitapi(projectId, lang, tok) {
   return projectData;
 }
 
-export const load = async ({ locals, params }) => {
+export const load = async ({ locals, params, fetch }) => {
   const projectId = params.id;
   const lang = locals.lang;
   const tok = locals.tok;

--- a/src/routes/service/[id]/+page.server.js
+++ b/src/routes/service/[id]/+page.server.js
@@ -1,6 +1,6 @@
-import { SendTo } from '$lib/send/sendTo.svelte';
+import { sendToSer } from '$lib/send/sendToSer.js';
 import { langAdjast } from '$lib/func/langAdjast.svelte';
-export async function load({ locals, params }) {
+export async function load({ locals, params, fetch }) {
   const mId = params.id;
   const lang = locals.lang;
   const tok = locals.tok;
@@ -9,77 +9,33 @@ export async function load({ locals, params }) {
   let error;
   let bdata = []
   let fullfild = false
-  let toc;
   let archived = false
-  if (tok != false) {
-    toc = tok;
-  } else {
-    toc = import.meta.env.VITE_ADMINMONTHER;
-  }
-  que = `{ 
-    matanot (id:${mId}) {data{attributes{ name pic{data{attributes{url}}} price quant kindOf desc publishedAt
-           archived startDate finnishDate
-    projectcreates {data{ id attributes{ projectName
-     user_1s{data{id}} restime timeToP profilePic {data{ attributes{url  }}}
-      open_missions{data{id attributes{ sqadualed
-           archived
-          tafkidims {data{attributes{roleDescription ${
-            lang == 'he'
-              ? 'localizations{data{attributes{ roleDescription }}}'
-              : ''
-          }}}}
-          skills {data{attributes{skillName ${
-            lang == 'he' ? 'localizations{data{attributes{skillName }}}' : ''
-          }}}}
-          descrip
-          hearotMeyuchadot
-          name dates iskvua
-          work_ways {data{attributes{workWayName ${
-            lang == 'he'
-              ? 'localizations{data{attributes{workWayName }}}'
-              : ''
-          }}}}
-          noofhours perhour 
-        }}}
-          }}}
-        }}}
-  }
-          `;
-  alld = new Promise((resolve) => {
-    SendTo(que, toc)
-      .then((data) => {
-        console.log(data);
-        if (data.data.matanot.data != null) {
-          const datar = data.data.matanot.data.attributes;
-          console.log(datar);
-          if (datar.archived != true) {
-            const langd = datar//langAdjast(datar, lang);
-            data = langd;
-            data.archived = false;
-            data = data;
-            console.log(datar.projectcreates.data)
-            data.title = {
-              he: `1💗1 | שירות "${datar.name}" בריקמה: ${datar.projectcreates.data[0].attributes.projectName}`,
-              en: `1💗1 | come see this service "${datar.name}" on freeMates:"${datar.projectcreates.data[0].attributes.projectName}"`
-            };
-            data.fullfild = true;
-            console.log(fullfild);
-          } else {
-            data = { archived: true };
-            data = data;
-            archived = true;
-            data.fullfild = true;
-          }
-        } else {
-          data = null;
+  const isSer = tok === false;
+  alld = new Promise(async (resolve) => {
+    try {
+      const res = await sendToSer({ id: mId }, '42MatanotById', null, null, isSer, fetch);
+      const datar = res?.data?.matanot?.data?.attributes;
+      if (datar) {
+        if (datar.archived != true) {
+          const data = datar;
+          data.archived = false;
+          data.title = {
+            he: `1💗1 | שירות "${datar.name}" בריקמה: ${datar.projectcreates.data[0].attributes.projectName}`,
+            en: `1💗1 | come see this service "${datar.name}" on freeMates:"${datar.projectcreates.data[0].attributes.projectName}"`
+          };
           data.fullfild = true;
-          console.log(fullfild);
+          resolve(data);
+        } else {
+          archived = true;
+          resolve({ archived: true, fullfild: true });
         }
-        return resolve(data);
-      })
-      .catch((error) => {
-        console.log(error);
-      });
+      } else {
+        resolve({ archived: true, fullfild: true });
+      }
+    } catch (e) {
+      console.log(e);
+      resolve(null);
+    }
   });
   return {
     uid,

--- a/src/routes/user/[id]/+page.server.js
+++ b/src/routes/user/[id]/+page.server.js
@@ -1,181 +1,13 @@
-import { SendTo } from '$lib/send/sendTo.svelte';
+import { sendToSer } from '$lib/send/sendToSer.js';
 import { langAdjast } from '$lib/func/langAdjast.svelte';
 
 async function awaitapi(userId, lang, tok) {
-  let que, toc;
-  if (tok != false) {
-    que = `{
-      usersPermissionsUser (id:${userId}) {
-        data {
-          id
-          attributes {
-            fblink
-            twiterlink
-            discordlink
-            githublink
-            bio
-            username
-            finnished_missions {
-              data {
-                attributes {
-                  missionName
-                }
-              }
-            }
-            profilePic {
-              data {
-                attributes {
-                  url
-                  formats
-                }
-              }
-            }
-            projects_1s {
-              data {
-                id
-                attributes {
-                  projectName
-                }
-              }
-            }
-            sps (filters: {archived:{eq: false }}) {
-              data {
-                id
-                attributes {
-                  name
-                  panui
-                }
-              }
-            }
-            skills {
-              data {
-                id
-                attributes {
-                  skill Name 
- localizations{data{attributes{skillName}}}
-                }
-              }
-            }
-            tafkidims {
-              data {
-                id
-                attributes {
-                  roleDescription  localizations{data{attributes{roleDescription}}}
-                }
-              }
-            }
-            vallues {
-              data {
-                id
-                attributes {
-                  valueName  localizations{data{attributes{valueName}}}
-                }
-              }
-            }
-            work_ways {
-              data {
-                id
-                attributes {
-                  workWayName  localizations{data{attributes{workWayName}}}
-                }
-              }
-            }
-          }
-        }
-      }
-    }`;
-    toc = tok;
-  } else {
-    que = `{
-      usersPermissionsUser (id:${userId}) {
-        data {
-          id
-          attributes {
-            fblink
-            twiterlink
-            discordlink
-            githublink
-            bio
-            username
-            finnished_missions {
-              data {
-                attributes {
-                  missionName
-                }
-              }
-            }
-            profilePic {
-              data {
-                attributes {
-                  url
-                  formats
-                }
-              }
-            }
-            projects_1s {
-              data {
-                id
-                attributes {
-                  projectName
-                }
-              }
-            }
-            sps (filters: {archived:{eq: false }}) {
-              data {
-                id
-                attributes {
-                  name
-                  panui
-                }
-              }
-            }
-            skills {
-              data {
-                id
-                attributes {
-                  skillName  localizations{data{attributes{skillName}}}
-                }
-              }
-            }
-            tafkidims {
-              data {
-                id
-                attributes {
-                  roleDescription  localizations{data{attributes{roleDescription}}}
-                }
-              }
-            }
-            vallues {
-              data {
-                id
-                attributes {
-                  valueName  localizations{data{attributes{valueName}}}
-                }
-              }
-            }
-            work_ways {
-              data {
-                id
-                attributes {
-                  workWayName  localizations{data{attributes{workWayName}}}
-                }
-              }
-            }
-          }
-        }
-      }
-    }`;
-    toc = import.meta.env.VITE_ADMINMONTHER;
-  }
-
   let userData = null;
   try {
-    const data = await SendTo(que, toc);
-    console.log(data);
-    if (data.data.usersPermissionsUser.data != null) {
-      let datar = data.data.usersPermissionsUser.data;
-      userData = datar;
-      console.log(userData);
+    const isSer = tok === false;
+    const data = await sendToSer({ uid: userId }, '43UserById', null, null, isSer, fetch);
+    if (data?.data?.usersPermissionsUser?.data) {
+      userData = data.data.usersPermissionsUser.data;
     }
   } catch (error) {
     console.error("Error fetching user data:", error);
@@ -184,7 +16,7 @@ async function awaitapi(userId, lang, tok) {
   return userData;
 }
 
-export const load = async ({ locals, params }) => {
+export const load = async ({ locals, params, fetch }) => {
   const userId = params.id;
   const lang = locals.lang;
   const tok = locals.tok;


### PR DESCRIPTION
Centralize GraphQL queries by migrating several components and server loads from direct `SendTo` calls to `sendToSer` with new `qids.js` entries.

---
<a href="https://cursor.com/background-agent?bcId=bc-95cc48c0-4d72-4b29-a6b2-a7c37d38ece3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-95cc48c0-4d72-4b29-a6b2-a7c37d38ece3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

