### PR TITLE
fix: add server-side auth guard to (reg) layout to prevent login-wall loop

### DIFF
--- a/src/routes/(reg)/+layout.server.js
+++ b/src/routes/(reg)/+layout.server.js
@@ -1,10 +1,19 @@
+import { redirect } from '@sveltejs/kit';
+
 export function load({ locals, url }) {
+    const tok = locals.tok;
+
+    // Server-side auth guard: redirect unauthenticated users to login
+    // before the page renders, eliminating the login-wall flash/loop.
+    if (!tok) {
+        throw redirect(303, `/login?from=${url.pathname}`);
+    }
+
     const userAgent = locals.userAgent;
-    const tok = locals.tok
-    const un = locals.un
-    const from = url.pathname
-    const uid = locals.uid
-    console.log(from)
+    const un = locals.un;
+    const from = url.pathname;
+    const uid = locals.uid;
+    console.log(from);
     return {
         userAgent,
         tok,

--- a/src/routes/(reg)/+layout.svelte
+++ b/src/routes/(reg)/+layout.svelte
@@ -39,41 +39,31 @@ console.log('Message received. ', payload);
 
   /** @type {Props} */
   let { data, children } = $props();
-let isAuthed = $state(false);
+// isAuthed is derived synchronously from server data so there is no
+// flash of the login wall after a successful login redirect.
+let isAuthed = $state(!!data.tok);
 let token;
 onMount(async () => {
-
+    // Check session expiry via the 'when' cookie
     const cookieRe = document.cookie
-  .split('; ')
-  .find(row => row.startsWith('when='))
-  if (cookieRe != null) {
-  const cookieR = document.cookie
-  .split('; ')
-  .find(row => row.startsWith('when='))
-  .split('=')[1];
-  const today = Date.now()
-  if(new Date(cookieR +2592000000) < today ){
-    goto("login")
-  }
-  }
-    if (data.tok){
-      console.log("auted")
-    isAuthed = true
-    initialForum(true,[],data.uid)
-    console.log(data.uid,$forum)
-    initialWebS(data.tok,data.uid)
-    initialWebSP(data.tok,data.uid)
+      .split('; ')
+      .find(row => row.startsWith('when='));
+    if (cookieRe != null) {
+      const cookieR = cookieRe.split('=')[1];
+      const today = Date.now();
+      if (new Date(+cookieR + 2592000000) < today) {
+        goto('/login');
+        return;
+      }
+    }
 
-} else {
-   // jwt is httpOnly now; rely on server-provided token or the 'when' cookie for auth flag
-  const cookieT = document.cookie
-    .split('; ')
-    .find(row => row.startsWith('when='))
-    ?.split('=')[1];
-  if (cookieT != null) {
-    isAuthed = true;
-  }
-}
+    if (data.tok) {
+      console.log('authed');
+      initialForum(true, [], data.uid);
+      console.log(data.uid, $forum);
+      initialWebS(data.tok, data.uid);
+      initialWebSP(data.tok, data.uid);
+    }
 });
 function reg (){
   if ($lang && $lang == "he"){


### PR DESCRIPTION
Before this fix:
- (reg)/+layout.server.js had no auth check, so unauthenticated users
  could reach the page and see the login wall rendered client-side.
- (reg)/+layout.svelte initialised isAuthed = false, so even after a
  successful login the server-rendered HTML always showed the login wall
  until onMount ran and checked data.tok.
- This created a redirect loop: user logs in → redirected to /onboard →
  login wall shown (isAuthed still false) → user clicks login again → loop.

Changes:
1. src/routes/(reg)/+layout.server.js
   - Import redirect from @sveltejs/kit.
   - Throw redirect(303, /login?from=<pathname>) when locals.tok is falsy.
   - Unauthenticated requests never reach the layout/page render step.

2. src/routes/(reg)/+layout.svelte
   - Initialise isAuthed = $state(!!data.tok) so the value is correct
     on the very first render (SSR and hydration) with no flash of the wall.
   - Simplified onMount: keeps session-expiry check and service initialisers;
     removed the redundant isAuthed mutation and the when-cookie fallback
     (server redirect is now the source of truth for unauthed users).

https://claude.ai/code/session_01HVr4bP8ZgDYVTvahVWFjNo