### PR TITLE
feat(votes): broadcast live vote updates via socket instead of no-op

### DIFF
--- a/src/lib/server/actions/configs/voteOnDecision.ts
+++ b/src/lib/server/actions/configs/voteOnDecision.ts
@@ -192,9 +192,10 @@ const voteOnDecisionHandler: ActionExecutionHandler = async (params, context, { 
       );
     }
 
+    // Consensus archives the Decision and applies the project change — refresh everywhere.
     return {
       data: { decisionId, consensus: true, kind },
-      updateStrategy: { type: 'none' },
+      updateStrategy: { type: 'fullRefresh' },
     };
   } else {
     // ── NON-CONSENSUS: save updated vots ─────────────────────────────────────
@@ -205,9 +206,19 @@ const voteOnDecisionHandler: ActionExecutionHandler = async (params, context, { 
       context.fetch,
     );
 
+    // Vote in Strapi-nested shape so the decisions store can append it and
+    // processDecisions() recomputes the live counts for every member + device.
+    const strapiVote = {
+      what: true,
+      users_permissions_user: { data: { id: String(userId) } },
+      ide: parseInt(String(userId), 10),
+      zman: now.toISOString(),
+      order: 0,
+    };
+
     return {
-      data: { decisionId, consensus: false, kind, newVote },
-      updateStrategy: { type: 'none' },
+      data: { id: decisionId, newVote: strapiVote, consensus: false, kind },
+      updateStrategy: { type: 'partialUpdate', config: { dataKeys: ['decisions'] } },
     };
   }
 };
@@ -250,7 +261,7 @@ export const voteOnDecisionConfig: ActionConfig = {
   notification: {
     recipients: {
       type: 'projectMembers',
-      config: { projectIdParam: 'projectId', excludeSender: true },
+      config: { projectIdParam: 'projectId', excludeSender: false },
     },
     templates: {
       title: { he: 'הצבעה על החלטת פרויקט', en: 'Project decision vote' },

--- a/src/lib/server/actions/configs/voteOnMaap.ts
+++ b/src/lib/server/actions/configs/voteOnMaap.ts
@@ -104,6 +104,15 @@ const voteOnMaapHandler: ActionExecutionHandler = async (params, context, { stra
 
   const allVots = [...previousVotes, newVote];
 
+  // Vote in Strapi-nested shape for the wegets store (processWeget recomputes counts).
+  const strapiVote: Record<string, any> = {
+    what: Boolean(what),
+    users_permissions_user: { data: { id: strUserId } },
+    ide: parseInt(strUserId, 10),
+    zman: now.toISOString(),
+  };
+  if (why) strapiVote.why = why;
+
   // 4. Check YES consensus: all project members voted YES
   if (what === true) {
     const yesCount = allVots.filter(
@@ -194,13 +203,14 @@ const voteOnMaapHandler: ActionExecutionHandler = async (params, context, { stra
         throw new Error(`voteOnMaap consensus mutation failed: ${JSON.stringify(responseData.errors)}`);
       }
 
+      // Consensus archives the Maap and creates a Rikmash — refresh everywhere.
       return {
         data: {
           askId,
           rikmashId: responseData.data?.createRikmash?.data?.id,
           consensus: true,
         },
-        updateStrategy: { type: 'none' },
+        updateStrategy: { type: 'fullRefresh' },
       };
     }
   }
@@ -208,9 +218,10 @@ const voteOnMaapHandler: ActionExecutionHandler = async (params, context, { stra
   // ── No full YES consensus (or this is a NO vote) — save updated vots ──────
   await strapi.execute('153addVoteToMaap', { id: askId, vots: allVots }, context.jwt, context.fetch);
 
+  // Regular vote: broadcast the single new vote for live count updates everywhere.
   return {
-    data: { askId, consensus: false },
-    updateStrategy: { type: 'none' },
+    data: { id: askId, newVote: strapiVote, consensus: false },
+    updateStrategy: { type: 'partialUpdate', config: { dataKeys: ['wegets'] } },
   };
 };
 

--- a/src/lib/server/actions/configs/voteOnPendm.ts
+++ b/src/lib/server/actions/configs/voteOnPendm.ts
@@ -85,6 +85,17 @@ const voteOnPendmHandler: ActionExecutionHandler = async (params, context, { str
 
   const allVots = [...previousVotes, newVote];
 
+  // Vote in Strapi-nested shape, so receiving clients (levSocketHandler →
+  // pends store) can append it and let processPends() recompute the counts.
+  const strapiVote: Record<string, any> = {
+    what: Boolean(what),
+    users_permissions_user: { data: { id: strUserId } },
+    order: orderon,
+    ide: parseInt(strUserId, 10),
+    zman: now.toISOString(),
+  };
+  if (why) strapiVote.why = why;
+
   // 5. Count YES votes at orderon among project members
   const yesMemberCount = (() => {
     const yesSet = new Set(
@@ -175,13 +186,15 @@ const voteOnPendmHandler: ActionExecutionHandler = async (params, context, { str
       throw new Error(`voteOnPendm consensus mutation failed: ${JSON.stringify(responseData.errors)}`);
     }
 
+    // Consensus archives the pendm and creates an OpenMission — both the
+    // disappearing pend and the new mission must reflect everywhere, so refresh.
     return {
       data: {
         openMissionId: responseData.data?.createOpenMission?.data?.id,
         pendId,
         consensus: true,
       },
-      updateStrategy: { type: 'none' },
+      updateStrategy: { type: 'fullRefresh' },
     };
   }
 
@@ -201,13 +214,20 @@ const voteOnPendmHandler: ActionExecutionHandler = async (params, context, { str
 
   if (archiveOnNo) {
     await strapi.execute('143archivePendmWithVotes', { id: pendId, users: allVots }, context.jwt, context.fetch);
-  } else {
-    await strapi.execute('85addVoteToPend', { id: pendId, users: allVots }, context.jwt, context.fetch);
+    // Full NO consensus archives the pendm — it must disappear for everyone.
+    return {
+      data: { pendId, consensus: false, archived: true },
+      updateStrategy: { type: 'fullRefresh' },
+    };
   }
 
+  await strapi.execute('85addVoteToPend', { id: pendId, users: allVots }, context.jwt, context.fetch);
+
+  // Regular vote: broadcast the single new vote so every project member (and the
+  // voter's other devices) appends it and re-derives the live vote counts.
   return {
-    data: { pendId, consensus: false, archived: archiveOnNo },
-    updateStrategy: { type: 'none' },
+    data: { id: pendId, newVote: strapiVote, consensus: false, archived: false },
+    updateStrategy: { type: 'partialUpdate', config: { dataKeys: ['pends'] } },
   };
 };
 

--- a/src/lib/server/actions/configs/voteOnPmash.ts
+++ b/src/lib/server/actions/configs/voteOnPmash.ts
@@ -82,6 +82,16 @@ const voteOnPmashHandler: ActionExecutionHandler = async (params, context, { str
 
   const allVots = [...previousVotes, newVote];
 
+  // Vote in Strapi-nested shape for the pmashes store (processPmash recomputes counts).
+  const strapiVote: Record<string, any> = {
+    what: Boolean(what),
+    users_permissions_user: { data: { id: strUserId } },
+    order: orderon,
+    ide: parseInt(strUserId, 10),
+    zman: now.toISOString(),
+  };
+  if (why) strapiVote.why = why;
+
   // 5. Count YES votes at orderon among project members
   const yesMemberCount = (() => {
     const yesSet = new Set(
@@ -168,9 +178,10 @@ const voteOnPmashHandler: ActionExecutionHandler = async (params, context, { str
       throw new Error(`voteOnPmash consensus mutation failed: ${JSON.stringify(responseData.errors)}`);
     }
 
+    // Consensus archives the pmash and creates an OpenMashaabim — refresh everywhere.
     return {
       data: { pmashId, consensus: true },
-      updateStrategy: { type: 'none' },
+      updateStrategy: { type: 'fullRefresh' },
     };
   }
 
@@ -190,13 +201,19 @@ const voteOnPmashHandler: ActionExecutionHandler = async (params, context, { str
 
   if (archiveOnNo) {
     await strapi.execute('145archivePmashWithVotes', { id: pmashId, users: allVots }, context.jwt, context.fetch);
-  } else {
-    await strapi.execute('146addVoteToPmash', { id: pmashId, users: allVots }, context.jwt, context.fetch);
+    // Full NO consensus archives the pmash — it must disappear for everyone.
+    return {
+      data: { pmashId, consensus: false, archived: true },
+      updateStrategy: { type: 'fullRefresh' },
+    };
   }
 
+  await strapi.execute('146addVoteToPmash', { id: pmashId, users: allVots }, context.jwt, context.fetch);
+
+  // Regular vote: broadcast the single new vote for live count updates everywhere.
   return {
-    data: { pmashId, consensus: false, archived: archiveOnNo },
-    updateStrategy: { type: 'none' },
+    data: { id: pmashId, newVote: strapiVote, consensus: false, archived: false },
+    updateStrategy: { type: 'partialUpdate', config: { dataKeys: ['pmashes'] } },
   };
 };
 

--- a/src/lib/utils/levSocketHandler.ts
+++ b/src/lib/utils/levSocketHandler.ts
@@ -174,6 +174,48 @@ function extractData(data: any): any {
 }
 
 /**
+ * Extract a voter id from a vote object regardless of shape
+ * (nested Strapi relation, flat id, or `ide` fallback).
+ */
+function voterIdOf(vote: any): string | undefined {
+  const id =
+    vote?.users_permissions_user?.data?.id ??
+    vote?.users_permissions_user?.id ??
+    vote?.users_permissions_user ??
+    vote?.ide;
+  return id != null ? String(id) : undefined;
+}
+
+/**
+ * Append a vote to an item's vote array idempotently.
+ *
+ * Removes any prior vote by the same voter (optionally only at the same `order`,
+ * to preserve historical votes from earlier negotiation rounds) and appends the
+ * new one. This makes the update safe to apply repeatedly — including the echo
+ * the voting device receives for its own action — without double counting, and
+ * it correctly reflects a member changing their vote.
+ *
+ * Returns the new array, or null when the vote can't be identified (caller should
+ * then leave the store untouched).
+ */
+function mergeVote(existing: any[] | undefined, newVote: any, matchOrder: boolean): any[] | null {
+  const voterId = voterIdOf(newVote);
+  if (!voterId) return null;
+
+  const arr = Array.isArray(existing) ? existing : [];
+  const order = newVote.order ?? 0;
+
+  const filtered = arr.filter((v: any) => {
+    if (voterIdOf(v) !== voterId) return true;
+    // Same voter: drop the conflicting vote so the new one replaces it.
+    if (matchOrder) return (v.order ?? 0) !== order; // keep votes from other rounds
+    return false;
+  });
+
+  return [...filtered, newVote];
+}
+
+/**
  * Handle partial update of specific stores
  * 
  * This updates only the stores specified in dataKeys with the provided data.
@@ -309,7 +351,17 @@ export function updatePendsStore(data: Partial<PendMissionData> & { id: string }
     if (index !== -1) {
       // Update existing item
       console.log('✏️ [levSocketHandler] Updating existing pend', { id: data.id });
-      current[index] = { ...current[index], ...data };
+
+      const newVote = (data as any).newVote;
+      if (newVote) {
+        // Append the vote (order-aware) so processPends re-derives the counts.
+        const merged = mergeVote((current[index] as any).users, newVote, true);
+        if (merged) {
+          current[index] = { ...current[index], users: merged } as PendMissionData;
+        }
+      } else {
+        current[index] = { ...current[index], ...data };
+      }
     } else {
       // Add new item
       console.log('➕ [levSocketHandler] Adding new pend', { id: data.id });
@@ -491,7 +543,16 @@ export function updatePmashesStore(data: Partial<PendResourceData> & { id: strin
 
     if (index !== -1) {
       console.log('✏️ [levSocketHandler] Updating existing pmash', { id: data.id });
-      current[index] = { ...current[index], ...data };
+
+      const newVote = (data as any).newVote;
+      if (newVote) {
+        const merged = mergeVote((current[index] as any).users, newVote, true);
+        if (merged) {
+          current[index] = { ...current[index], users: merged } as PendResourceData;
+        }
+      } else {
+        current[index] = { ...current[index], ...data };
+      }
     } else {
       console.log('➕ [levSocketHandler] Adding new pmash', { id: data.id });
       current.push(data as PendResourceData);
@@ -524,7 +585,17 @@ export function updateWegetsStore(data: Partial<ResourceRequestData> & { id: str
 
     if (index !== -1) {
       console.log('✏️ [levSocketHandler] Updating existing weget', { id: data.id });
-      current[index] = { ...current[index], ...data };
+
+      const newVote = (data as any).newVote;
+      if (newVote) {
+        // Maap/weget votes live on `vots` and have no order (one vote per member).
+        const merged = mergeVote((current[index] as any).vots, newVote, false);
+        if (merged) {
+          current[index] = { ...current[index], vots: merged } as ResourceRequestData;
+        }
+      } else {
+        current[index] = { ...current[index], ...data };
+      }
     } else {
       console.log('➕ [levSocketHandler] Adding new weget', { id: data.id });
       current.push(data as ResourceRequestData);

--- a/src/routes/(reg)/moach/[projectId]/+layout.svelte
+++ b/src/routes/(reg)/moach/[projectId]/+layout.svelte
@@ -43,13 +43,29 @@
     socketUnsubscribe = socketClient.onNotification((notification) => {
       console.log('[MoachLayout] Socket notification:', notification);
 
+      if (!projectId) return;
+
+      // Ignore notifications that belong to a different project (the socket
+      // delivers events for every project the user is a member of).
+      const notifProjectId =
+        notification.actionParams?.projectId || notification.data?.projectId;
+      if (notifProjectId && String(notifProjectId) !== String(projectId)) return;
+
       // If notification implies data change, invalidate store cache
       // type could be 'mission', 'base', 'financials' etc depending on backend payload
       const type = notification.metadata?.type || notification.data?.type;
-      if (type && projectId) {
+
+      // Vote notifications (incl. consensus, which may create a mission/resource
+      // or change project details) touch several cached sections.
+      const VOTE_TYPES = ['pendmVote', 'pmashVote', 'maapVote', 'decisionVote', 'voteUpdate'];
+
+      if (type && VOTE_TYPES.includes(type)) {
+        moachStore.invalidate(projectId, 'base');
+        moachStore.invalidate(projectId, 'missions');
+        moachStore.invalidate(projectId, 'financials');
+      } else if (type) {
         moachStore.invalidate(projectId, type);
-        // Optionally trigger re-fetch immediately for active tab
-      } else if (projectId) {
+      } else {
         // Broad invalidation if type unknown
         moachStore.invalidate(projectId, 'base');
         moachStore.invalidate(projectId, 'missions');

--- a/src/routes/(reg)/moach/[projectId]/votes/+page.svelte
+++ b/src/routes/(reg)/moach/[projectId]/votes/+page.svelte
@@ -2,22 +2,45 @@
   import { page } from '$app/state';
   import { lang } from '$lib/stores/lang.js';
   import { sendToSer } from '$lib/send/sendToSer.js';
-  import { onMount } from 'svelte';
+  import { onMount, onDestroy } from 'svelte';
   import Lowding from '$lib/celim/lowding.svelte';
   import { goto } from '$app/navigation';
+  import { socketClient } from '$lib/stores/socketClient';
 
   let projectId = $derived(page.params.projectId);
   let votesData = $state(null);
   let loading = $state(true);
 
-  onMount(async () => {
+  async function loadVotes() {
     try {
       const res = await sendToSer({ pid: projectId }, 'getProjectVotes', null, null, false, fetch);
       votesData = res?.data?.project?.data?.attributes;
     } finally {
       loading = false;
     }
+  }
+
+  // Realtime: refresh the open-votes list whenever a vote lands for this project.
+  const VOTE_TYPES = ['pendmVote', 'pmashVote', 'maapVote', 'decisionVote', 'voteUpdate'];
+  let socketUnsub;
+
+  onMount(() => {
+    loadVotes();
+    socketUnsub = socketClient.onNotification((n) => {
+      const type = n?.metadata?.type || n?.data?.type;
+      const notifProjectId = n?.actionParams?.projectId || n?.data?.projectId;
+      if (
+        notifProjectId &&
+        String(notifProjectId) === String(projectId) &&
+        type &&
+        VOTE_TYPES.includes(type)
+      ) {
+        loadVotes();
+      }
+    });
   });
+
+  onDestroy(() => socketUnsub?.());
 
   const i18n = {
     he: { title: 'הצבעות פתוחות', splitVotes: 'הצבעות חלוקה', joinVotes: 'בקשות הצטרפות', decisionVotes: 'החלטות' },

--- a/src/routes/(regandnon)/project/[id]/+page.server.js
+++ b/src/routes/(regandnon)/project/[id]/+page.server.js
@@ -20,11 +20,14 @@ async function awaitapi(projectId, lang, tok, fetch) {
   return projectData;
 }
 
-export const load = async ({ locals, params, fetch }) => {
+export const load = async ({ locals, params, fetch, depends }) => {
   const projectId = params.id;
   const lang = locals.lang;
   const tok = locals.tok;
   const uid = locals.uid;
+  // Tag this load so a realtime vote/decision notification can re-run it
+  // via invalidate(`project:${projectId}`) from the page.
+  depends(`project:${projectId}`);
 console.log(projectId)
   let isRegisteredUser = tok != false;
 console.log(isRegisteredUser)

--- a/src/routes/(regandnon)/project/[id]/+page.svelte
+++ b/src/routes/(regandnon)/project/[id]/+page.svelte
@@ -1,50 +1,87 @@
 <script>
   import Header from '$lib/components/header/header.svelte';
-  import { goto } from '$app/navigation';
+  import { goto, invalidate } from '$app/navigation';
+  import { onMount, onDestroy } from 'svelte';
   import { lang } from '$lib/stores/lang.js';
   import { RingLoader } from 'svelte-loading-spinners';
   import Close from '$lib/celim/close.svelte';
   import RichText from '$lib/celim/ui/richText.svelte';
   import Tile from '$lib/celim/tile.svelte';
+  import { socketClient } from '$lib/stores/socketClient';
 
   // ייבוא הקומפוננטה החדשה (נניח שהיא באותה תיקייה או בתיקיית הקומפוננטות)
   import AuthorityBadge from '$lib/components/ui/AuthorityBadge.svelte';
 
   let { data } = $props();
-  let projectId = data.projectId;
-  let project = data.projectData;
-  let isRegisteredUser = data.isRegisteredUser;
+  // Derived so navigating between /project/A and /project/B (same component
+  // instance, reused by SvelteKit) keeps these — and the socket listener — current.
+  let projectId = $derived(data.projectId);
+  let isRegisteredUser = $derived(data.isRegisteredUser);
 
-  let projectUsers = project?.attributes?.user_1s?.data || [];
-  let projecto = project?.attributes?.open_missions?.data || [];
-  let vallues = $state(project?.attributes?.vallues?.data || []);
+  // Derived from load data so a realtime invalidate(`project:${id}`) re-renders
+  // the team, missions, logo, links and values (e.g. after a decision passes).
+  let project = $derived(data.projectData);
+  let projectUsers = $derived(project?.attributes?.user_1s?.data || []);
+  let projecto = $derived(project?.attributes?.open_missions?.data || []);
 
   // תמונה - בדיקת תקינות
-  let srcP = project?.attributes?.profilePic?.data
-    ? project.attributes.profilePic.data.attributes.formats?.thumbnail?.url ||
-      project.attributes.profilePic.data.attributes.url
-    : null;
+  let srcP = $derived(
+    project?.attributes?.profilePic?.data
+      ? project.attributes.profilePic.data.attributes.formats?.thumbnail?.url ||
+          project.attributes.profilePic.data.attributes.url
+      : null
+  );
 
-  let linkP = project?.attributes?.linkToWebsite;
-  let githublink = project?.attributes?.githubLink;
-  let fblink = project?.attributes?.fblink;
-  let discordlink = project?.attributes?.discordLink;
-  let twiterlink = project?.attributes?.twiterLink;
+  let linkP = $derived(project?.attributes?.linkToWebsite);
+  let githublink = $derived(project?.attributes?.githubLink);
+  let fblink = $derived(project?.attributes?.fblink);
+  let discordlink = $derived(project?.attributes?.discordLink);
+  let twiterlink = $derived(project?.attributes?.twiterLink);
 
   const showl = { he: '🎁 הצגת התוצרים שלנו', en: '🎁 Our Products' };
   let show = $state(false);
 
-  // טיפול בתרגום ערכים
+  // Values, re-synced from the (possibly re-fetched) project and translated for he.
+  let vallues = $state([]);
   $effect(() => {
-    if ($lang == 'he' && vallues.length > 0) {
-      for (let i = 0; i < vallues.length; i++) {
-        if (vallues[i].attributes.localizations.data.length > 0) {
-          vallues[i].attributes.valueName =
-            vallues[i].attributes.localizations.data[0].attributes.valueName;
+    const base = data.projectData?.attributes?.vallues?.data || [];
+    if ($lang == 'he') {
+      for (let i = 0; i < base.length; i++) {
+        const loc = base[i]?.attributes?.localizations?.data;
+        if (loc && loc.length > 0) {
+          base[i].attributes.valueName = loc[0].attributes.valueName;
         }
       }
     }
+    vallues = base;
   });
+
+  // Realtime: re-run the page load when a vote/decision lands for this project.
+  // Only registered users hold an authenticated socket connection.
+  const PROJECT_REFRESH_TYPES = [
+    'pendmVote',
+    'pmashVote',
+    'maapVote',
+    'decisionVote',
+    'voteUpdate'
+  ];
+  let socketUnsub;
+  onMount(() => {
+    if (!isRegisteredUser) return;
+    socketUnsub = socketClient.onNotification((n) => {
+      const type = n?.metadata?.type || n?.data?.type;
+      const notifProjectId = n?.actionParams?.projectId || n?.data?.projectId;
+      if (
+        notifProjectId &&
+        String(notifProjectId) === String(projectId) &&
+        type &&
+        PROJECT_REFRESH_TYPES.includes(type)
+      ) {
+        invalidate(`project:${projectId}`);
+      }
+    });
+  });
+  onDestroy(() => socketUnsub?.());
 
   function us(x) {
     goto(`/user/${x}`);


### PR DESCRIPTION
Vote actions (voteOnPendm/Pmash/Maap/Decision) returned updateStrategy:'none',
so the socket notification reached other project members and the voter's other
devices but triggered no store update — votes only appeared after a reload.

- Each vote action now returns the new vote (Strapi-nested) with a partialUpdate
  strategy on the right dataKey (pends/pmashes/wegets/decisions); consensus and
  full-NO archival transitions return fullRefresh since items appear/disappear.
- voteOnDecision: excludeSender false so the voter's other devices update too.
- levSocketHandler: pends/pmashes/wegets now append the vote idempotently
  (replace prior vote by the same voter, order-aware for re-votes) so the echo
  the voter receives is a no-op and processPends/Weget re-derive live counts.

https://claude.ai/code/session_012L1X8vPLQTxZXRBDxXQMUr