### PR TITLE
144 phase 0: user-sovereign consent infrastructure

### DIFF
--- a/docs/PLAN_user_sovereign_consent.md
+++ b/docs/PLAN_user_sovereign_consent.md
@@ -1,0 +1,294 @@
+# מודל נתונים ריבוני-משתמש עם הסכמה קריפטוגרפית
+
+## Context — למה זה נבנה
+
+ה-FreeMates/1lev1 מבוסס היום על Strapi מרכזי + JWT: השרת הוא הסמכות היחידה,
+וכל "הסכמה" (vote, approve, join) היא רשומה בודדת ב-DB שאי אפשר לאמת מבחוץ.
+התוצאה: אין הוכחה קריפטוגרפית שמשתמש באמת הסכים, ערך פרויקט מחושב על נתונים
+שהשרת יכול לשנות בלי חתימה, ואין מודל אחיד ל"מי הסכים על מה ומתי".
+
+המטרה: להפוך את **המשתמש למקור האמת**. כל מוטציה משמעותית בפרויקט הופכת
+ל**אירוע הסכמה חתום** שנשמר ב-DAG (Merkle-DAG) על המכשיר האישי, ומשוקף לשרת
+שמשמש כמראה בלבד. כל צד שלישי יכול לאמת חתימה מקומית מול המפתח הציבורי
+המפורסם של המשתמש, ומצב הפרויקט (מי חייב למי, רווחים, חברות) מחושב כ-
+**projection טהור** מעל לוג האירועים החתומים — event sourcing.
+
+### החלטות שהמשתמש קיבל
+- **טווח**: תשתית רחבה לכל הפעולות (לא רק tosplit). פעולה ראשונה מומלצת:
+  tosplit כי כבר יש לה דרישה לפה-אחד.
+- **מפתח פרטי**: היברידי — `Ed25519` ב-WebCrypto + IndexedDB (חתימת אירועים),
+  Passkey/WebAuthn כשער-משתמש שמשחרר גישה לחתימה (גם UX מוכר וגם דרישת פעולה
+  פיזית של בעל המכשיר).
+- **התאוששות מאיבוד מכשירים**: החלטה דחויה — Phase 2 יציין placeholder בלבד.
+
+---
+
+## ארכיטקטורה בקצרה
+
+```
+ ┌─────────────────────────────────────────────────────────────┐
+ │ Device (browser tab)                                        │
+ │   UI ──postMessage──► Service Worker (single key owner)     │
+ │                          │                                  │
+ │                          ├─ IndexedDB: privKey, events,     │
+ │                          │              deviceCerts          │
+ │                          └─ Passkey gate (user verification)│
+ │                          │                                  │
+ │                          └──► POST /api/consent/events ─────┼──► Strapi mirror
+ │                          ◄──  Socket.io: new event ids      │     (consent-event,
+ │                                                             │      user-key)
+ └─────────────────────────────────────────────────────────────┘
+                  ▲                                  ▲
+                  └──── peer verification ───────────┘
+              (any client fetches event + actor's pubkey,
+               verifies locally — no server trust needed)
+```
+
+מצב פרויקט = `project(events)` — פונקציה טהורה שמקפלת את האירועים החתומים
+לאובייקט `ProjectState` (חברים, balances, tosplits, halukas). UI הקיים ממשיך
+לעבוד כי הוא רק קורא את ה-projection.
+
+---
+
+## מודל האירוע הקנוני
+
+```ts
+type ConsentEvent = {
+  v: 1;
+  id: string;          // b64url(sha256(canonical(bytes without id)))
+  actor: string;       // userId
+  device: string;      // b64(SPKI) של המכשיר שחתם
+  action: string;      // 'tosplit.create' | 'tosplit.vote' | 'haluka.approve' | ...
+  subject: { type: string; id: string };
+  predicate?: Record<string, unknown>;
+  parents: string[];   // קצוות ב-DAG → ערעור הורה פוסל צאצא
+  ts: number;
+  nonce: string;       // 16B random
+  sig: string;         // Ed25519 על canonical(event ללא id/sig)
+};
+```
+
+`canonicalize` = JCS: keys ממוינים, ללא whitespace, NFC, מספרים דצימליים.
+הפסילה של חתימה אחת לא מערערת אחרות — DAG, לא chain.
+
+**מיפוי דוגמא — הצבעה על tosplit**: היום `vots[]` בתוך `tosplit`. במודל החדש:
+- היוצר חותם `tosplit.create` עם `subject.id = contentHash(proposal)`,
+  `parents = [sale.recorded ids]`, `predicate = { halukas, hervachti }`.
+- כל מצביע חותם `tosplit.vote` עם `parents = [tosplit.create id]`,
+  `predicate = { what: true|false }`.
+- "אישור פה-אחד" = ב-projection יש `tosplit.vote` תקף לכל חבר פעיל
+  (חבר = יש לו `project.join` שלא בוטל).
+
+---
+
+## מבנה קבצים חדש
+
+```
+src/lib/crypto/
+  algorithm.ts          # זיהוי Ed25519/ECDSA-P256 fallback
+  canonical.ts          # JCS-style deterministic JSON
+  b64.ts                # b64url helpers
+  keystore.ts           # עטיפת IndexedDB ל-CryptoKey non-extractable
+  identity.ts           # ensureIdentity(userId): יצירה/טעינה
+  passkey.ts            # WebAuthn gate שמתיר חתימה לסשן קצוב
+  sign.ts               # signEvent, signDeviceCert
+  verify.ts             # verifyEvent + chain walk של DeviceCert
+
+src/lib/consent/
+  event.ts              # types + constants של action namespace
+  store.svelte.ts       # $state-backed event log (מ-IndexedDB)
+  ingest.ts             # verify + dedupe + append
+  sync.ts               # pull diff מהמראה / push pending
+  devicePairing.ts      # QR pair flow
+  projection.ts         # פונקציה טהורה events → ProjectState
+  reducers/
+    index.ts            # dispatch table לפי action
+    tosplitCreate.ts
+    tosplitVote.ts
+    halukaApprove.ts
+    projectJoin.ts
+    deviceCert.ts
+
+src/lib/components/consent/
+  PairDeviceQr.svelte
+  ScanPairQr.svelte
+  ConsentBadge.svelte   # תווית "מאומת" ליד הצבעה
+  DevicesPanel.svelte
+
+src/routes/api/consent/
+  events/+server.ts             # POST שיקוף, GET לפי subject
+  events/[id]/+server.ts        # GET אירוע בודד
+  keys/register/+server.ts      # POST מפתח ציבורי + DeviceCert
+  keys/[userId]/+server.ts      # GET מפתחות פעילים
+  devices/cert/+server.ts       # POST cert מ-pairing
+
+src/routes/(reg)/me/devices/+page.svelte
+```
+
+קבצים קיימים לעריכה:
+- `src/service-worker.js` — להוסיף message handler `consent.sign` + `sync` tag.
+- `src/lib/server/actions/configs/createTosplit.ts` — `signedEvents` param,
+  אימות צד-שרת, שיקוף ל-`consent-event`.
+- `src/lib/server/actions/configs/addVote.ts` — ענף `type:'tosplit'`
+  שדורש `signedEvent` תקף.
+- `src/routes/(reg)/moach/[projectId]/split/+page.svelte` — `ConsentBadge` +
+  קריאה מ-projection במקום מ-denormalized.
+- `src/lib/stores/moachStore.svelte.js` — להחזיק `ProjectState` במקביל,
+  invalidate על אירוע חדש מ-socket.
+- `src/lib/components/prPr/hachcal.svelte` ו-`src/lib/components/lev/halukaask.svelte`
+  — לחתום לפני `sendToSer`.
+
+תלות חדשה: שום ספרייה חיצונית — WebCrypto + WebAuthn מובנים.
+(לצד-שרת ב-Node 22: `node:crypto.webcrypto` תומך ב-Ed25519 מאז 21.7.)
+
+---
+
+## Service Worker — בעלים יחיד של המפתח
+
+ה-SW נבחר כי:
+1. תהליך יחיד שמחזיק את ה-`CryptoKey` non-extractable (אין race בין טאבים).
+2. יכול לחתום ולסנכרן ברקע (`background-sync`) גם כשהטאב סגור.
+3. כבר קיים בקוד (`src/service-worker.js`) — מוסיפים handler, לא יוצרים תהליך חדש.
+
+קוד שיתווסף (סכמטי):
+```js
+self.addEventListener('message', async (ev) => {
+  if (ev.data?.type === 'consent.sign') {
+    const ok = await ensurePasskeyGate();           // משחרר ל-N דקות
+    if (!ok) return ev.ports[0].postMessage({ ok: false, reason: 'gate' });
+    const signed = await signEventInSw(ev.data.payload);
+    await idbAdd('pendingSync', signed);
+    self.registration.sync.register('consent-sync').catch(() => {});
+    ev.ports[0].postMessage({ ok: true, event: signed });
+  }
+});
+self.addEventListener('sync', (ev) => {
+  if (ev.tag === 'consent-sync') ev.waitUntil(flushPending());
+});
+```
+
+UI מדבר עם ה-SW דרך `MessageChannel` (לא Broadcast — כדי לקבל reply ממוקד).
+
+---
+
+## Multi-device pairing (Phase 2)
+
+מודל אמון: כל מכשיר מאושר על-ידי `DeviceCert` חתום של מכשיר מאושר קיים.
+המכשיר הראשון = trust-on-first-use עם אימות email out-of-band.
+
+```ts
+type DeviceCert = {
+  v: 1; kind: 'deviceCert';
+  userId: string;
+  devicePubKey: string;             // b64(SPKI)
+  deviceLabel: string;
+  capabilities: ('sign' | 'admin')[];
+  notBefore: number; notAfter?: number;
+  parentDevicePubKey: string;       // החותם
+  nonce: string;
+  sig: string;
+};
+```
+
+זרימה: מכשיר חדש מציג QR `{userId, devicePubKey, nonce}` → מכשיר קיים סורק,
+משתמש מאשר → חתימה → publish ל-`/api/consent/devices/cert`.
+
+ביטול: כל מכשיר מאושר יכול לחתום `device.revoke` — ה-projection מחשיב מפתח
+כפעיל רק אם cert תקף ולא בוטל ב-`ts` של האירוע.
+
+---
+
+## פאזות הטמעה
+
+### Phase 0 — תשתית קריפטו (1 שבוע)
+- `src/lib/crypto/*` כולל unit tests (`vitest` + `fast-check` ל-canonical).
+- `src/lib/consent/event.ts` + `store.svelte.ts` בסיסי.
+- הרחבת `service-worker.js` עם handler חתימה, מאחורי `localStorage.CONSENT_ENABLED`.
+- routes שרת: `keys/register`, `keys/[userId]`, `events` (POST+GET).
+
+**Exit**: round-trip sign→verify עובר בטסטים; טאב יכול ליצור זהות ולחתום
+אירוע דמה דרך ה-SW.
+
+### Phase 1 — Shadow signing על tosplit (1 שבוע)
+- `voteOnTosplit` חותם אירוע במקביל לקריאת `addVote` הקיימת.
+- `createTosplit` מצרף `signedEvents` ל-payload; השרת משקף ל-`consent-event`
+  אבל לא חוסם.
+- `ConsentBadge` ירוק/אפור ב-UI split.
+- `projection.ts` רץ במקביל — מתועד discrepancy ל-console.
+
+**Exit**: ≥95% הצבעות חדשות מאומתות; projection תואם.
+
+### Phase 2 — Pairing + ניהול מכשירים (1 שבוע)
+- דף `/me/devices` עם QR + רשימת מכשירים.
+- `device.revoke` reducer.
+- Passkey gate ב-SW (משחרר חתימה לחלון של N דקות).
+- placeholder UI להתאוששות (decision נדחה).
+
+**Exit**: בדיקה ידנית — pairing טלפון מלפטופ, חתימה מהטלפון, אימות מדפדפן שלישי.
+
+### Phase 3 — אכיפה ל-tosplit (1 שבוע)
+- `createTosplit` ו-`addVote` (ענף tosplit) דוחים בלי signedEvent תקף.
+- split page קוראת בלעדית מ-projection. ה-denormalized קאש בלבד.
+- tosplits ישנים מסומנים "legacy / לא מאומת".
+
+**Exit**: כל פעילות tosplit חדשה מבוססת קריפטוגרפית.
+
+### Phase 4 — הרחבה לפעולות נוספות
+פעולה ל-PR, שבוע shadow לפני אכיפה. סדר מומלץ:
+`approveHaluka` → `approveMatanot` → `approveSheirutpend` →
+`projectJoin/leave` → `completeMission` → שאר ה-actions בתיקיית configs.
+
+### Phase 5 — verifiability ציבורית (אופציונלי)
+`GET /v/:eventId` — דף ללא login שמאמת מול pubkey מפורסם. שימושי למחלוקות.
+
+---
+
+## פונקציות לשימוש חוזר מהקוד הקיים
+
+- `sendToSer` (`src/lib/send/sendToSer.js`) — נשאר נקודת הכניסה לשרת.
+  ה-action החדש `consentEvent` יישלח דרכו כדי לקבל בחינם את retry/auth/socket.
+- `moachStore` (`src/lib/stores/moachStore.svelte.js`) — דפוס ה-cache עם TTL
+  ו-localStorage שיכפול שלו ל-`consentStore` (אבל גיבוי ב-IndexedDB, לא localStorage,
+  כי `CryptoKey` לא serializable ל-localStorage).
+- מערכת ה-actions ב-`src/lib/server/actions/configs/` — לכל reducer חדש נוסיף
+  action config שמשכפל את הפורמט הקיים.
+- Socket.io הקיים (broadcast מהשרת) — נוסיף ערוץ `consent:event` עם event-id;
+  הלקוח שולף מהמראה.
+
+---
+
+## סיכונים פתוחים
+
+1. **התאוששות מאיבוד כל המכשירים** — נדחה. עד שיוחלט: אם משתמש איבד הכל,
+   הוא מאבד יכולת לחתום במקום המזהה הנוכחי; אירועים ישנים שלו נשארים תקפים.
+2. **GDPR vs immutable log** — payload רגיש מאוחסן off-event וניתן ל-tombstone;
+   האירוע מצביע אל hash.
+3. **גידול לוג** — Phase 5: snapshots חתומים על-ידי quorum.
+4. **race של חתימות מקבילות** — dedupe לפי `(actor, subject, action, order)`;
+   שניהם נשמרים לאודיט, last-by-ts wins.
+
+---
+
+## תכנית אימות
+
+### Unit (Vitest)
+- `canonical.test.ts` — fast-check: `canonical(parse(canonical(x))) === canonical(x)`.
+- `sign.test.ts` — round-trip Ed25519 + fallback; tamper נכשל; מפתח לא נכון נכשל.
+- `projection.test.ts` — סדר אקראי של אירועים בעלי DAG זהה → אותו state
+  (commutativity תחת topo-sort).
+- `devicePairing.test.ts` — cert מבוטל פוסל אירועים בעלי `ts > revokedAt`.
+
+### Integration
+- `routes/api/consent/events/+server.test.ts` — POST עם stub pubkey resolver;
+  signature מזויפת → 400.
+- `createTosplit.integration.test.ts` — happy path: bootstrap → sign → create →
+  שתי זהויות מצביעות → projection מציג אישור.
+
+### Manual (browser, end-to-end)
+שני דפדפנים על `/moach/<id>/split`:
+1. Chrome יוצר tosplit, חותם create + vote. devtools → IndexedDB יראה אירועים.
+2. Firefox טוען — `ConsentBadge` מאמת. חותם vote משלו.
+3. Reload Chrome — projection מראה אישור פה-אחד.
+4. Offline test: לכבות רשת ב-Firefox, להצביע, לראות SW מצטבר ב-`pendingSync`,
+   להחזיר רשת, לראות sync.
+5. Pairing test: לזווג טלפון, להצביע ממנו, לאמת מדפדפן שלישי.

--- a/src/lib/consent/event.ts
+++ b/src/lib/consent/event.ts
@@ -1,0 +1,70 @@
+// Canonical shape of a signed consent event.
+// Every meaningful mutation in the project becomes one of these.
+
+export type ConsentEvent = {
+  v: 1;
+  id: string;          // b64url(sha256(canonical(body+sig)))
+  actor: string;       // userId
+  device: string;      // b64(SPKI) of signing device
+  action: ActionName;
+  subject: { type: string; id: string };
+  predicate?: Record<string, unknown>;
+  parents: string[];   // DAG edges; tampering an ancestor invalidates descendants
+  ts: number;
+  nonce: string;
+  sig: string;
+};
+
+export type DeviceCert = {
+  v: 1;
+  kind: 'deviceCert';
+  id: string;
+  userId: string;
+  devicePubKey: string;        // the device being authorized
+  deviceLabel: string;
+  capabilities: ('sign' | 'admin')[];
+  notBefore: number;
+  notAfter?: number;
+  parentDevicePubKey: string;  // signer; equals devicePubKey for first device (self-cert)
+  actor: string;               // userId (kept for signature lookup uniformity)
+  device: string;              // alias for parentDevicePubKey, used by verify pipeline
+  nonce: string;
+  sig: string;
+};
+
+export const ACTIONS = {
+  tosplitCreate:   'tosplit.create',
+  tosplitVote:     'tosplit.vote',
+  halukaCreate:    'haluka.create',
+  halukaApprove:   'haluka.approve',
+  projectCreate:   'project.create',
+  projectJoin:     'project.join',
+  projectLeave:    'project.leave',
+  missionComplete: 'mission.complete',
+  deviceCert:      'device.cert',
+  deviceRevoke:    'device.revoke'
+} as const;
+
+export type ActionName = typeof ACTIONS[keyof typeof ACTIONS];
+
+export function dedupeKey(ev: ConsentEvent): string {
+  const order = (ev.predicate?.order as number | undefined) ?? 0;
+  return `${ev.actor}|${ev.subject.type}:${ev.subject.id}|${ev.action}|${order}`;
+}
+
+export function isConsentEventShape(x: unknown): x is ConsentEvent {
+  if (!x || typeof x !== 'object') return false;
+  const o = x as Record<string, unknown>;
+  return (
+    o.v === 1 &&
+    typeof o.id === 'string' &&
+    typeof o.actor === 'string' &&
+    typeof o.device === 'string' &&
+    typeof o.action === 'string' &&
+    !!o.subject && typeof o.subject === 'object' &&
+    Array.isArray(o.parents) &&
+    typeof o.ts === 'number' &&
+    typeof o.nonce === 'string' &&
+    typeof o.sig === 'string'
+  );
+}

--- a/src/lib/consent/ingest.ts
+++ b/src/lib/consent/ingest.ts
@@ -1,0 +1,25 @@
+import { verifySignedObject, type PubKeyResolver } from '$lib/crypto/verify';
+import { idbAdd, idbGet } from '$lib/crypto/keystore';
+import { isConsentEventShape, type ConsentEvent } from './event';
+
+export type IngestResult =
+  | { ok: true; deduped: false; event: ConsentEvent }
+  | { ok: true; deduped: true;  event: ConsentEvent }
+  | { ok: false; reason: string };
+
+export async function ingestEvent(
+  raw: unknown,
+  resolve: PubKeyResolver
+): Promise<IngestResult> {
+  if (!isConsentEventShape(raw)) return { ok: false, reason: 'bad_shape' };
+  const ev = raw as ConsentEvent;
+
+  const existing = await idbGet<ConsentEvent>('events', ev.id);
+  if (existing) return { ok: true, deduped: true, event: existing };
+
+  const v = await verifySignedObject(ev, resolve);
+  if (!v.ok) return { ok: false, reason: v.reason };
+
+  await idbAdd('events', ev);
+  return { ok: true, deduped: false, event: ev };
+}

--- a/src/lib/consent/projection.test.ts
+++ b/src/lib/consent/projection.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from 'vitest';
+import { project, topoSort } from './projection';
+import type { ConsentEvent } from './event';
+
+function ev(partial: Partial<ConsentEvent> & { id: string; action: string; parents?: string[] }): ConsentEvent {
+  return {
+    v: 1,
+    id: partial.id,
+    actor: partial.actor ?? 'user-1',
+    device: partial.device ?? 'dev-1',
+    action: partial.action as ConsentEvent['action'],
+    subject: partial.subject ?? { type: 'tosplit', id: 'ts-1' },
+    predicate: partial.predicate,
+    parents: partial.parents ?? [],
+    ts: partial.ts ?? 0,
+    nonce: partial.nonce ?? 'n',
+    sig: partial.sig ?? 's'
+  };
+}
+
+describe('topoSort', () => {
+  it('puts parents before children', () => {
+    const a = ev({ id: 'a', action: 'project.create', ts: 1 });
+    const b = ev({ id: 'b', action: 'project.join', parents: ['a'], ts: 2 });
+    const c = ev({ id: 'c', action: 'project.join', parents: ['a'], ts: 3 });
+    const sorted = topoSort([c, b, a]);
+    expect(sorted.map((e) => e.id)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('orders independent events by ts then id', () => {
+    const a = ev({ id: 'a', action: 'project.join', ts: 2 });
+    const b = ev({ id: 'b', action: 'project.join', ts: 1 });
+    const sorted = topoSort([a, b]);
+    expect(sorted.map((e) => e.id)).toEqual(['b', 'a']);
+  });
+});
+
+describe('project: tosplit voting', () => {
+  it('flags tosplit approved when all members vote what:true', () => {
+    const projectId = 'proj-1';
+    const events: ConsentEvent[] = [
+      ev({ id: 'j1', actor: 'u1', action: 'project.join', subject: { type: 'project', id: projectId }, ts: 1 }),
+      ev({ id: 'j2', actor: 'u2', action: 'project.join', subject: { type: 'project', id: projectId }, ts: 2 }),
+      ev({ id: 'tc', actor: 'u1', action: 'tosplit.create',
+           subject: { type: 'tosplit', id: 'ts-1' },
+           predicate: { halukas: [] }, parents: [], ts: 3 }),
+      ev({ id: 'v1', actor: 'u1', action: 'tosplit.vote',
+           subject: { type: 'tosplit', id: 'ts-1' },
+           predicate: { what: true }, parents: ['tc'], ts: 4 }),
+      ev({ id: 'v2', actor: 'u2', action: 'tosplit.vote',
+           subject: { type: 'tosplit', id: 'ts-1' },
+           predicate: { what: true }, parents: ['tc'], ts: 5 })
+    ];
+    const state = project(events, projectId);
+    expect(state.members.has('u1')).toBe(true);
+    expect(state.members.has('u2')).toBe(true);
+    const view = state.tosplits.get('ts-1')!;
+    expect(view).toBeTruthy();
+    expect(view.approved).toBe(true);
+  });
+
+  it('does not approve when one member did not vote', () => {
+    const projectId = 'proj-1';
+    const events: ConsentEvent[] = [
+      ev({ id: 'j1', actor: 'u1', action: 'project.join', subject: { type: 'project', id: projectId }, ts: 1 }),
+      ev({ id: 'j2', actor: 'u2', action: 'project.join', subject: { type: 'project', id: projectId }, ts: 2 }),
+      ev({ id: 'tc', actor: 'u1', action: 'tosplit.create',
+           subject: { type: 'tosplit', id: 'ts-1' }, parents: [], ts: 3 }),
+      ev({ id: 'v1', actor: 'u1', action: 'tosplit.vote',
+           subject: { type: 'tosplit', id: 'ts-1' },
+           predicate: { what: true }, parents: ['tc'], ts: 4 })
+    ];
+    const state = project(events, projectId);
+    expect(state.tosplits.get('ts-1')!.approved).toBe(false);
+  });
+
+  it('does not approve when one member rejects', () => {
+    const projectId = 'proj-1';
+    const events: ConsentEvent[] = [
+      ev({ id: 'j1', actor: 'u1', action: 'project.join', subject: { type: 'project', id: projectId }, ts: 1 }),
+      ev({ id: 'j2', actor: 'u2', action: 'project.join', subject: { type: 'project', id: projectId }, ts: 2 }),
+      ev({ id: 'tc', actor: 'u1', action: 'tosplit.create',
+           subject: { type: 'tosplit', id: 'ts-1' }, parents: [], ts: 3 }),
+      ev({ id: 'v1', actor: 'u1', action: 'tosplit.vote',
+           subject: { type: 'tosplit', id: 'ts-1' },
+           predicate: { what: true }, parents: ['tc'], ts: 4 }),
+      ev({ id: 'v2', actor: 'u2', action: 'tosplit.vote',
+           subject: { type: 'tosplit', id: 'ts-1' },
+           predicate: { what: false }, parents: ['tc'], ts: 5 })
+    ];
+    const state = project(events, projectId);
+    expect(state.tosplits.get('ts-1')!.approved).toBe(false);
+  });
+
+  it('last vote per actor wins (revote)', () => {
+    const projectId = 'proj-1';
+    const events: ConsentEvent[] = [
+      ev({ id: 'j1', actor: 'u1', action: 'project.join', subject: { type: 'project', id: projectId }, ts: 1 }),
+      ev({ id: 'tc', actor: 'u1', action: 'tosplit.create',
+           subject: { type: 'tosplit', id: 'ts-1' }, parents: [], ts: 2 }),
+      ev({ id: 'v1', actor: 'u1', action: 'tosplit.vote',
+           subject: { type: 'tosplit', id: 'ts-1' },
+           predicate: { what: false }, parents: ['tc'], ts: 3 }),
+      ev({ id: 'v2', actor: 'u1', action: 'tosplit.vote',
+           subject: { type: 'tosplit', id: 'ts-1' },
+           predicate: { what: true }, parents: ['tc'], ts: 4 })
+    ];
+    const state = project(events, projectId);
+    expect(state.tosplits.get('ts-1')!.approved).toBe(true);
+  });
+
+  it('member leaving removes them from members set', () => {
+    const projectId = 'proj-1';
+    const events: ConsentEvent[] = [
+      ev({ id: 'j1', actor: 'u1', action: 'project.join', subject: { type: 'project', id: projectId }, ts: 1 }),
+      ev({ id: 'j2', actor: 'u2', action: 'project.join', subject: { type: 'project', id: projectId }, ts: 2 }),
+      ev({ id: 'l2', actor: 'u2', action: 'project.leave', subject: { type: 'project', id: projectId }, parents: ['j2'], ts: 3 })
+    ];
+    const state = project(events, projectId);
+    expect(state.members.has('u1')).toBe(true);
+    expect(state.members.has('u2')).toBe(false);
+  });
+});
+
+describe('project: commutativity under topo-sort', () => {
+  it('produces same state regardless of input order', () => {
+    const projectId = 'proj-1';
+    const events: ConsentEvent[] = [
+      ev({ id: 'j1', actor: 'u1', action: 'project.join', subject: { type: 'project', id: projectId }, ts: 1 }),
+      ev({ id: 'j2', actor: 'u2', action: 'project.join', subject: { type: 'project', id: projectId }, ts: 2 }),
+      ev({ id: 'tc', actor: 'u1', action: 'tosplit.create',
+           subject: { type: 'tosplit', id: 'ts-1' }, parents: [], ts: 3 }),
+      ev({ id: 'v1', actor: 'u1', action: 'tosplit.vote',
+           subject: { type: 'tosplit', id: 'ts-1' },
+           predicate: { what: true }, parents: ['tc'], ts: 4 }),
+      ev({ id: 'v2', actor: 'u2', action: 'tosplit.vote',
+           subject: { type: 'tosplit', id: 'ts-1' },
+           predicate: { what: true }, parents: ['tc'], ts: 5 })
+    ];
+    const a = project(events, projectId);
+    const b = project([...events].reverse(), projectId);
+    expect(a.members).toEqual(b.members);
+    expect(a.tosplits.get('ts-1')!.approved).toBe(b.tosplits.get('ts-1')!.approved);
+  });
+});

--- a/src/lib/consent/projection.ts
+++ b/src/lib/consent/projection.ts
@@ -1,0 +1,101 @@
+import type { ConsentEvent } from './event';
+import { dedupeKey } from './event';
+import { reducers } from './reducers';
+
+export type TosplitView = {
+  id: string;
+  createdBy: string;
+  createdAt: number;
+  predicate: Record<string, unknown> | undefined;
+  votes: Map<string, { what: boolean; ts: number; eventId: string }>;
+  approved: boolean;
+};
+
+export type ProjectState = {
+  projectId: string | null;
+  members: Set<string>;
+  balances: Map<string, number>;
+  tosplits: Map<string, TosplitView>;
+  asOf: number;
+};
+
+export function emptyState(projectId: string | null = null): ProjectState {
+  return {
+    projectId,
+    members: new Set(),
+    balances: new Map(),
+    tosplits: new Map(),
+    asOf: 0
+  };
+}
+
+// Topological sort: parents before children. Ties broken by ts then id.
+export function topoSort(events: ConsentEvent[]): ConsentEvent[] {
+  const byId = new Map(events.map((e) => [e.id, e]));
+  const indeg = new Map<string, number>();
+  for (const e of events) indeg.set(e.id, 0);
+  for (const e of events) {
+    for (const p of e.parents) {
+      if (byId.has(p)) indeg.set(e.id, (indeg.get(e.id) ?? 0) + 1);
+    }
+  }
+  const ready: ConsentEvent[] = events.filter((e) => (indeg.get(e.id) ?? 0) === 0);
+  const sortReady = (arr: ConsentEvent[]) =>
+    arr.sort((a, b) => (a.ts - b.ts) || a.id.localeCompare(b.id));
+  sortReady(ready);
+
+  const result: ConsentEvent[] = [];
+  const childrenOf = new Map<string, string[]>();
+  for (const e of events) {
+    for (const p of e.parents) {
+      if (!byId.has(p)) continue;
+      const arr = childrenOf.get(p) ?? [];
+      arr.push(e.id);
+      childrenOf.set(p, arr);
+    }
+  }
+
+  while (ready.length) {
+    const next = ready.shift()!;
+    result.push(next);
+    for (const childId of childrenOf.get(next.id) ?? []) {
+      const d = (indeg.get(childId) ?? 1) - 1;
+      indeg.set(childId, d);
+      if (d === 0) {
+        ready.push(byId.get(childId)!);
+        sortReady(ready);
+      }
+    }
+  }
+  // Cycle or dangling parents: append remaining by ts/id for resilience.
+  if (result.length !== events.length) {
+    const placed = new Set(result.map((e) => e.id));
+    const rest = events.filter((e) => !placed.has(e.id));
+    sortReady(rest);
+    result.push(...rest);
+  }
+  return result;
+}
+
+export function applyEvent(prev: ProjectState, ev: ConsentEvent): ProjectState {
+  const reducer = reducers[ev.action];
+  const next = reducer ? reducer(prev, ev) : prev;
+  next.asOf = Math.max(prev.asOf, ev.ts);
+  return next;
+}
+
+export function project(events: ConsentEvent[], projectId: string | null = null): ProjectState {
+  const ordered = topoSort(events);
+  // dedupe: keep the latest-ts entry per (actor, subject, action, order)
+  const byKey = new Map<string, ConsentEvent>();
+  for (const e of ordered) {
+    const k = dedupeKey(e);
+    const cur = byKey.get(k);
+    if (!cur || e.ts > cur.ts) byKey.set(k, e);
+  }
+  const finalEvents = ordered.filter((e) => byKey.get(dedupeKey(e)) === e);
+
+  let state = emptyState(projectId);
+  for (const e of finalEvents) state = applyEvent(state, e);
+  return state;
+}

--- a/src/lib/consent/publish.ts
+++ b/src/lib/consent/publish.ts
@@ -1,0 +1,71 @@
+import { browser } from '$app/environment';
+import { b64urlEncode } from '$lib/crypto/b64';
+import { ensureIdentity, type IdentityRecord } from '$lib/crypto/identity';
+import { idbAdd } from '$lib/crypto/keystore';
+import type { ConsentEvent } from './event';
+import { buildAndSignEvent, type SignableEvent } from './signEvent';
+
+// Lightweight orchestrator used directly from UI code. It:
+// 1. ensures the local identity exists (lazy bootstrap)
+// 2. registers the device pubkey with the server mirror if not yet known
+// 3. signs the event locally
+// 4. ships it to the mirror at /api/consent/events
+// 5. on network failure, queues to IDB and returns ok:false so callers don't block
+
+let pubkeyPublished = false;
+
+async function publishPubkey(identity: IdentityRecord) {
+  if (pubkeyPublished) return;
+  if (!browser) return;
+  try {
+    const pubSpkiB64 = b64urlEncode(identity.pubSpki);
+    const res = await fetch('/api/consent/keys/register', {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        userId: identity.userId,
+        devicePubB64: identity.devicePubB64,
+        algo: identity.algo,
+        pubSpkiB64,
+        label: navigator.userAgent.slice(0, 40)
+      })
+    });
+    if (res.ok) pubkeyPublished = true;
+  } catch {
+    // best-effort; the event POST will fail until the key is published
+  }
+}
+
+export type PublishResult =
+  | { ok: true; event: ConsentEvent }
+  | { ok: false; reason: string; event: ConsentEvent };
+
+export async function signAndPublish(
+  userId: string,
+  partial: SignableEvent
+): Promise<PublishResult> {
+  const identity = await ensureIdentity(userId);
+  await publishPubkey(identity);
+
+  const event = await buildAndSignEvent(identity, { ...partial, actor: userId });
+
+  if (!browser) return { ok: false, reason: 'not_browser', event };
+
+  try {
+    const res = await fetch('/api/consent/events', {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ event })
+    });
+    if (!res.ok) {
+      await idbAdd('pendingSync', event);
+      return { ok: false, reason: `http_${res.status}`, event };
+    }
+    return { ok: true, event };
+  } catch (e) {
+    await idbAdd('pendingSync', event);
+    return { ok: false, reason: 'network_' + (e as Error).message, event };
+  }
+}

--- a/src/lib/consent/reducers/index.ts
+++ b/src/lib/consent/reducers/index.ts
@@ -1,0 +1,15 @@
+import type { ConsentEvent } from '../event';
+import type { ProjectState } from '../projection';
+import { tosplitCreate } from './tosplitCreate';
+import { tosplitVote } from './tosplitVote';
+import { projectJoin } from './projectJoin';
+import { projectLeave } from './projectLeave';
+
+export type Reducer = (state: ProjectState, ev: ConsentEvent) => ProjectState;
+
+export const reducers: Record<string, Reducer> = {
+  'tosplit.create': tosplitCreate,
+  'tosplit.vote':   tosplitVote,
+  'project.join':   projectJoin,
+  'project.leave':  projectLeave
+};

--- a/src/lib/consent/reducers/projectJoin.ts
+++ b/src/lib/consent/reducers/projectJoin.ts
@@ -1,0 +1,12 @@
+import type { ConsentEvent } from '../event';
+import type { ProjectState } from '../projection';
+
+export function projectJoin(state: ProjectState, ev: ConsentEvent): ProjectState {
+  // subject.id is projectId; if state has no projectId yet, infer.
+  const projectId = state.projectId ?? ev.subject.id;
+  if (projectId !== ev.subject.id) return state;
+
+  const members = new Set(state.members);
+  members.add(ev.actor);
+  return { ...state, projectId, members };
+}

--- a/src/lib/consent/reducers/projectLeave.ts
+++ b/src/lib/consent/reducers/projectLeave.ts
@@ -1,0 +1,9 @@
+import type { ConsentEvent } from '../event';
+import type { ProjectState } from '../projection';
+
+export function projectLeave(state: ProjectState, ev: ConsentEvent): ProjectState {
+  if (state.projectId !== ev.subject.id) return state;
+  const members = new Set(state.members);
+  members.delete(ev.actor);
+  return { ...state, members };
+}

--- a/src/lib/consent/reducers/tosplitCreate.ts
+++ b/src/lib/consent/reducers/tosplitCreate.ts
@@ -1,0 +1,16 @@
+import type { ConsentEvent } from '../event';
+import type { ProjectState, TosplitView } from '../projection';
+
+export function tosplitCreate(state: ProjectState, ev: ConsentEvent): ProjectState {
+  const tosplits = new Map(state.tosplits);
+  const view: TosplitView = {
+    id: ev.subject.id,
+    createdBy: ev.actor,
+    createdAt: ev.ts,
+    predicate: ev.predicate,
+    votes: new Map(),
+    approved: false
+  };
+  tosplits.set(ev.subject.id, view);
+  return { ...state, tosplits };
+}

--- a/src/lib/consent/reducers/tosplitVote.ts
+++ b/src/lib/consent/reducers/tosplitVote.ts
@@ -1,0 +1,29 @@
+import type { ConsentEvent } from '../event';
+import type { ProjectState, TosplitView } from '../projection';
+
+export function tosplitVote(state: ProjectState, ev: ConsentEvent): ProjectState {
+  const view = state.tosplits.get(ev.subject.id);
+  if (!view) return state;
+
+  const what = Boolean((ev.predicate as { what?: unknown } | undefined)?.what);
+  const votes = new Map(view.votes);
+  votes.set(ev.actor, { what, ts: ev.ts, eventId: ev.id });
+
+  const approves: string[] = [];
+  for (const [actor, v] of votes) if (v.what) approves.push(actor);
+
+  // Unanimity over current members. If we have no member set yet (early phase),
+  // fall back to "approved when at least one approve and no reject".
+  let approved: boolean;
+  if (state.members.size > 0) {
+    approved = [...state.members].every((m) => votes.get(m)?.what === true);
+  } else {
+    approved = approves.length > 0 &&
+      [...votes.values()].every((v) => v.what === true);
+  }
+
+  const updated: TosplitView = { ...view, votes, approved };
+  const tosplits = new Map(state.tosplits);
+  tosplits.set(view.id, updated);
+  return { ...state, tosplits };
+}

--- a/src/lib/consent/signEvent.ts
+++ b/src/lib/consent/signEvent.ts
@@ -1,0 +1,36 @@
+import { signCanonical } from '$lib/crypto/sign';
+import { randomNonceB64 } from '$lib/crypto/b64';
+import type { IdentityRecord } from '$lib/crypto/identity';
+import type { ConsentEvent, ActionName } from './event';
+
+export type SignableEvent = {
+  actor: string;
+  action: ActionName;
+  subject: { type: string; id: string };
+  predicate?: Record<string, unknown>;
+  parents?: string[];
+  ts?: number;
+};
+
+export async function buildAndSignEvent(
+  identity: IdentityRecord,
+  partial: SignableEvent
+): Promise<ConsentEvent> {
+  const body = {
+    v: 1 as const,
+    actor: partial.actor,
+    device: identity.devicePubB64,
+    action: partial.action,
+    subject: partial.subject,
+    predicate: partial.predicate,
+    parents: partial.parents ?? [],
+    ts: partial.ts ?? Date.now(),
+    nonce: randomNonceB64()
+  };
+  const { sig, id } = await signCanonical(
+    body as unknown as import('$lib/crypto/canonical').JsonValue,
+    identity.privateKey,
+    identity.algo
+  );
+  return { ...body, sig, id };
+}

--- a/src/lib/consent/store.svelte.ts
+++ b/src/lib/consent/store.svelte.ts
@@ -1,0 +1,92 @@
+import { browser } from '$app/environment';
+import { setContext, getContext } from 'svelte';
+import { idbAll, idbBySubject } from '$lib/crypto/keystore';
+import { ingestEvent } from './ingest';
+import { project, type ProjectState } from './projection';
+import type { ConsentEvent } from './event';
+import type { PubKeyResolver } from '$lib/crypto/verify';
+
+const CONSENT_STORE_KEY = Symbol('CONSENT_STORE');
+
+export type ConsentStore = ReturnType<typeof createConsentStore>;
+
+export function createConsentStore() {
+  let state = $state({
+    eventsById: new Map<string, ConsentEvent>(),
+    loaded: false
+  });
+
+  async function load() {
+    if (!browser || state.loaded) return;
+    const all = await idbAll<ConsentEvent>('events');
+    const byId = new Map<string, ConsentEvent>();
+    for (const e of all) byId.set(e.id, e);
+    state.eventsById = byId;
+    state.loaded = true;
+  }
+
+  async function ingest(raw: unknown, resolve: PubKeyResolver) {
+    const res = await ingestEvent(raw, resolve);
+    if (res.ok && !res.deduped) {
+      const next = new Map(state.eventsById);
+      next.set(res.event.id, res.event);
+      state.eventsById = next;
+    }
+    return res;
+  }
+
+  function appendVerified(ev: ConsentEvent) {
+    if (state.eventsById.has(ev.id)) return;
+    const next = new Map(state.eventsById);
+    next.set(ev.id, ev);
+    state.eventsById = next;
+  }
+
+  function eventsForSubject(subjectType: string, subjectId: string): ConsentEvent[] {
+    const out: ConsentEvent[] = [];
+    for (const e of state.eventsById.values()) {
+      if (e.subject.type === subjectType && e.subject.id === subjectId) out.push(e);
+    }
+    return out;
+  }
+
+  function projectFor(projectId: string): ProjectState {
+    // For now: project off the full set. Future: index by project once we add
+    // a project tag to events.
+    return project([...state.eventsById.values()], projectId);
+  }
+
+  async function refreshFromIdb(subjectType?: string, subjectId?: string) {
+    if (!browser) return;
+    if (subjectType && subjectId) {
+      const arr = await idbBySubject<ConsentEvent>(subjectType, subjectId);
+      const next = new Map(state.eventsById);
+      for (const e of arr) next.set(e.id, e);
+      state.eventsById = next;
+    } else {
+      await load();
+    }
+  }
+
+  return {
+    get state() { return state; },
+    load,
+    ingest,
+    appendVerified,
+    eventsForSubject,
+    projectFor,
+    refreshFromIdb
+  };
+}
+
+export function setConsentStore(): ConsentStore {
+  const store = createConsentStore();
+  setContext(CONSENT_STORE_KEY, store);
+  return store;
+}
+
+export function getConsentStore(): ConsentStore {
+  const s = getContext<ConsentStore>(CONSENT_STORE_KEY);
+  if (!s) throw new Error('ConsentStore not initialized — call setConsentStore() in a layout');
+  return s;
+}

--- a/src/lib/crypto/algorithm.ts
+++ b/src/lib/crypto/algorithm.ts
@@ -1,0 +1,33 @@
+// Detect best available signature algorithm at runtime.
+// Ed25519 is preferred. Falls back to ECDSA P-256 on older browsers.
+
+export type SigAlgo = 'Ed25519' | 'ECDSA-P256';
+
+export function algoParams(algo: SigAlgo): EcKeyImportParams | Algorithm {
+  return algo === 'Ed25519'
+    ? { name: 'Ed25519' }
+    : { name: 'ECDSA', namedCurve: 'P-256' };
+}
+
+export function signParams(algo: SigAlgo): AlgorithmIdentifier | EcdsaParams {
+  return algo === 'Ed25519'
+    ? { name: 'Ed25519' }
+    : { name: 'ECDSA', hash: 'SHA-256' };
+}
+
+let cached: SigAlgo | null = null;
+
+export async function chooseAlgorithm(): Promise<SigAlgo> {
+  if (cached) return cached;
+  try {
+    await crypto.subtle.generateKey({ name: 'Ed25519' }, false, ['sign', 'verify']);
+    cached = 'Ed25519';
+  } catch {
+    cached = 'ECDSA-P256';
+  }
+  return cached;
+}
+
+export function resetAlgorithmCache() {
+  cached = null;
+}

--- a/src/lib/crypto/b64.ts
+++ b/src/lib/crypto/b64.ts
@@ -1,0 +1,21 @@
+export function b64urlEncode(bytes: ArrayBuffer | Uint8Array): string {
+  const view = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+  let s = '';
+  for (let i = 0; i < view.length; i++) s += String.fromCharCode(view[i]);
+  return btoa(s).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+export function b64urlDecode(s: string): Uint8Array<ArrayBuffer> {
+  const pad = s.length % 4 === 2 ? '==' : s.length % 4 === 3 ? '=' : '';
+  const b64 = s.replace(/-/g, '+').replace(/_/g, '/') + pad;
+  const bin = atob(b64);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out as Uint8Array<ArrayBuffer>;
+}
+
+export function randomNonceB64(byteLen = 16): string {
+  const buf = new Uint8Array(byteLen);
+  crypto.getRandomValues(buf);
+  return b64urlEncode(buf);
+}

--- a/src/lib/crypto/canonical.test.ts
+++ b/src/lib/crypto/canonical.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import fc from 'fast-check';
+import { canonicalize, type JsonValue } from './canonical';
+
+describe('canonicalize', () => {
+  it('orders object keys lexicographically', () => {
+    expect(canonicalize({ b: 1, a: 2 })).toBe('{"a":2,"b":1}');
+  });
+
+  it('preserves array order', () => {
+    expect(canonicalize([3, 1, 2])).toBe('[3,1,2]');
+  });
+
+  it('drops undefined values', () => {
+    expect(canonicalize({ a: 1, b: undefined as unknown as JsonValue })).toBe('{"a":1}');
+  });
+
+  it('serializes primitives', () => {
+    expect(canonicalize(null)).toBe('null');
+    expect(canonicalize(true)).toBe('true');
+    expect(canonicalize(false)).toBe('false');
+    expect(canonicalize(0)).toBe('0');
+    expect(canonicalize('x')).toBe('"x"');
+  });
+
+  it('throws on non-finite numbers', () => {
+    expect(() => canonicalize(Infinity)).toThrow();
+    expect(() => canonicalize(NaN)).toThrow();
+  });
+
+  it('is idempotent under parse/serialize', () => {
+    fc.assert(
+      fc.property(fc.jsonValue(), (v) => {
+        const s1 = canonicalize(v as JsonValue);
+        const s2 = canonicalize(JSON.parse(s1));
+        return s1 === s2;
+      }),
+      { numRuns: 200 }
+    );
+  });
+
+  it('is order-independent for object keys', () => {
+    fc.assert(
+      fc.property(
+        fc.dictionary(fc.string({ minLength: 1, maxLength: 8 }), fc.integer()),
+        (obj) => {
+          const keys = Object.keys(obj);
+          const shuffled: Record<string, number> = {};
+          for (const k of [...keys].reverse()) shuffled[k] = obj[k];
+          return canonicalize(obj) === canonicalize(shuffled);
+        }
+      ),
+      { numRuns: 100 }
+    );
+  });
+});

--- a/src/lib/crypto/canonical.ts
+++ b/src/lib/crypto/canonical.ts
@@ -1,0 +1,45 @@
+// Deterministic JSON serialization (RFC 8785 JCS, simplified for our needs).
+// - object keys sorted lexicographically by UTF-16 code units
+// - strings emitted with JSON.stringify (NFC normalization applied first)
+// - numbers: finite only, via JSON.stringify (no trailing zeros from V8)
+// - no whitespace
+// - undefined values are dropped (matches JSON.stringify behavior)
+// - arrays preserve order
+
+export type JsonValue =
+  | null
+  | boolean
+  | number
+  | string
+  | JsonValue[]
+  | { [k: string]: JsonValue | undefined };
+
+export function canonicalize(value: JsonValue): string {
+  if (value === null) return 'null';
+  const t = typeof value;
+  if (t === 'boolean') return value ? 'true' : 'false';
+  if (t === 'number') {
+    if (!Number.isFinite(value as number)) {
+      throw new Error('canonicalize: non-finite number');
+    }
+    return JSON.stringify(value);
+  }
+  if (t === 'string') return JSON.stringify((value as string).normalize('NFC'));
+  if (Array.isArray(value)) {
+    return '[' + value.map((v) => canonicalize(v as JsonValue)).join(',') + ']';
+  }
+  if (t === 'object') {
+    const obj = value as { [k: string]: JsonValue | undefined };
+    const keys = Object.keys(obj).filter((k) => obj[k] !== undefined).sort();
+    const parts: string[] = [];
+    for (const k of keys) {
+      parts.push(JSON.stringify(k.normalize('NFC')) + ':' + canonicalize(obj[k] as JsonValue));
+    }
+    return '{' + parts.join(',') + '}';
+  }
+  throw new Error('canonicalize: unsupported type ' + t);
+}
+
+export function canonicalBytes(value: JsonValue): Uint8Array<ArrayBuffer> {
+  return new TextEncoder().encode(canonicalize(value)) as Uint8Array<ArrayBuffer>;
+}

--- a/src/lib/crypto/identity.ts
+++ b/src/lib/crypto/identity.ts
@@ -1,0 +1,57 @@
+import { algoParams, chooseAlgorithm, type SigAlgo } from './algorithm';
+import { idbGet, idbPut } from './keystore';
+import { b64urlEncode } from './b64';
+
+export type IdentityRecord = {
+  id: 'self';
+  userId: string;
+  algo: SigAlgo;
+  privateKey: CryptoKey;
+  publicKey: CryptoKey;
+  pubSpki: ArrayBuffer;
+  devicePubB64: string;
+  createdAt: number;
+};
+
+export async function ensureIdentity(userId: string): Promise<IdentityRecord> {
+  const existing = await idbGet<IdentityRecord>('identity', 'self');
+  if (existing && existing.userId === userId) return existing;
+
+  const algo = await chooseAlgorithm();
+  const params = algoParams(algo);
+  const kp = (await crypto.subtle.generateKey(
+    params as Algorithm,
+    false,
+    ['sign', 'verify']
+  )) as CryptoKeyPair;
+
+  const pubSpki = await crypto.subtle.exportKey('spki', kp.publicKey);
+  const devicePubB64 = b64urlEncode(pubSpki);
+
+  const record: IdentityRecord = {
+    id: 'self',
+    userId,
+    algo,
+    privateKey: kp.privateKey,
+    publicKey: kp.publicKey,
+    pubSpki,
+    devicePubB64,
+    createdAt: Date.now()
+  };
+  await idbPut('identity', record);
+  return record;
+}
+
+export async function loadIdentity(): Promise<IdentityRecord | undefined> {
+  return idbGet<IdentityRecord>('identity', 'self');
+}
+
+export async function importPublicKey(
+  spki: ArrayBuffer | Uint8Array,
+  algo: SigAlgo
+): Promise<CryptoKey> {
+  const buf: ArrayBuffer = spki instanceof Uint8Array
+    ? spki.buffer.slice(spki.byteOffset, spki.byteOffset + spki.byteLength) as ArrayBuffer
+    : spki;
+  return crypto.subtle.importKey('spki', buf, algoParams(algo) as AlgorithmIdentifier, true, ['verify']);
+}

--- a/src/lib/crypto/keystore.ts
+++ b/src/lib/crypto/keystore.ts
@@ -1,0 +1,109 @@
+// Thin IndexedDB wrapper for storing identity, events, and pending sync items.
+// CryptoKey objects are structured-cloned into IndexedDB and remain non-extractable.
+
+import { browser } from '$app/environment';
+
+const DB_NAME = 'freemates-crypto';
+const DB_VERSION = 1;
+
+export type StoreName =
+  | 'identity'
+  | 'devices'
+  | 'events'
+  | 'peerKeys'
+  | 'pendingSync';
+
+let dbPromise: Promise<IDBDatabase> | null = null;
+
+function openDb(): Promise<IDBDatabase> {
+  if (dbPromise) return dbPromise;
+  dbPromise = new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, DB_VERSION);
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      if (!db.objectStoreNames.contains('identity')) {
+        db.createObjectStore('identity', { keyPath: 'id' });
+      }
+      if (!db.objectStoreNames.contains('devices')) {
+        db.createObjectStore('devices', { keyPath: 'devicePubKey' });
+      }
+      if (!db.objectStoreNames.contains('events')) {
+        const s = db.createObjectStore('events', { keyPath: 'id' });
+        s.createIndex('bySubject', ['subject.type', 'subject.id']);
+        s.createIndex('byActor', 'actor');
+        s.createIndex('byAction', 'action');
+      }
+      if (!db.objectStoreNames.contains('peerKeys')) {
+        db.createObjectStore('peerKeys', { keyPath: 'devicePubKey' });
+      }
+      if (!db.objectStoreNames.contains('pendingSync')) {
+        db.createObjectStore('pendingSync', { keyPath: 'id' });
+      }
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+  return dbPromise;
+}
+
+function req<T>(r: IDBRequest<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    r.onsuccess = () => resolve(r.result);
+    r.onerror = () => reject(r.error);
+  });
+}
+
+export async function idbGet<T = unknown>(store: StoreName, key: IDBValidKey): Promise<T | undefined> {
+  if (!browser && typeof indexedDB === 'undefined') return undefined;
+  const db = await openDb();
+  const tx = db.transaction(store, 'readonly');
+  return req<T>(tx.objectStore(store).get(key));
+}
+
+export async function idbPut(store: StoreName, value: unknown): Promise<void> {
+  const db = await openDb();
+  const tx = db.transaction(store, 'readwrite');
+  await req(tx.objectStore(store).put(value as object));
+}
+
+export async function idbAdd(store: StoreName, value: unknown): Promise<void> {
+  const db = await openDb();
+  const tx = db.transaction(store, 'readwrite');
+  await req(tx.objectStore(store).put(value as object));
+}
+
+export async function idbDelete(store: StoreName, key: IDBValidKey): Promise<void> {
+  const db = await openDb();
+  const tx = db.transaction(store, 'readwrite');
+  await req(tx.objectStore(store).delete(key));
+}
+
+export async function idbAll<T = unknown>(store: StoreName): Promise<T[]> {
+  const db = await openDb();
+  const tx = db.transaction(store, 'readonly');
+  return req<T[]>(tx.objectStore(store).getAll());
+}
+
+export async function idbBySubject<T = unknown>(
+  subjectType: string,
+  subjectId: string
+): Promise<T[]> {
+  const db = await openDb();
+  const tx = db.transaction('events', 'readonly');
+  const idx = tx.objectStore('events').index('bySubject');
+  return req<T[]>(idx.getAll([subjectType, subjectId]));
+}
+
+export async function resetDb(): Promise<void> {
+  if (dbPromise) {
+    const db = await dbPromise;
+    db.close();
+    dbPromise = null;
+  }
+  await new Promise<void>((resolve, reject) => {
+    const r = indexedDB.deleteDatabase(DB_NAME);
+    r.onsuccess = () => resolve();
+    r.onerror = () => reject(r.error);
+    r.onblocked = () => resolve();
+  });
+}

--- a/src/lib/crypto/passkey.ts
+++ b/src/lib/crypto/passkey.ts
@@ -1,0 +1,73 @@
+// Optional WebAuthn "gate": before letting the device sign a batch of consent
+// events, we require a fresh user-verification step (Touch ID / Face ID /
+// platform PIN). The Passkey isn't used to sign the consent events themselves —
+// raw WebCrypto signs those. The Passkey is the physical proof that the user is
+// present at the device at the time of signing.
+//
+// Gate lifetime is kept short (default 5 min) and stored in sessionStorage so it
+// doesn't survive a tab close.
+
+import { browser } from '$app/environment';
+
+const GATE_KEY = 'consent.gate.until';
+const DEFAULT_GATE_MS = 5 * 60_000;
+
+export function isPasskeyAvailable(): boolean {
+  return browser && typeof window !== 'undefined' &&
+    'PublicKeyCredential' in window &&
+    typeof navigator !== 'undefined' &&
+    !!navigator.credentials;
+}
+
+export function isGateOpen(now = Date.now()): boolean {
+  if (!browser) return false;
+  const until = Number(sessionStorage.getItem(GATE_KEY) ?? 0);
+  return until > now;
+}
+
+export function openGate(durationMs = DEFAULT_GATE_MS) {
+  if (!browser) return;
+  sessionStorage.setItem(GATE_KEY, String(Date.now() + durationMs));
+}
+
+export function closeGate() {
+  if (!browser) return;
+  sessionStorage.removeItem(GATE_KEY);
+}
+
+// Request a user-verification ceremony. If Passkeys aren't available we degrade
+// to a UI confirm() — the caller decides whether that's acceptable.
+export async function ensurePasskeyGate(opts: {
+  rpId?: string;
+  durationMs?: number;
+  fallbackConfirm?: () => boolean | Promise<boolean>;
+} = {}): Promise<boolean> {
+  if (isGateOpen()) return true;
+
+  if (isPasskeyAvailable()) {
+    try {
+      const challenge = new Uint8Array(32);
+      crypto.getRandomValues(challenge);
+      const cred = await navigator.credentials.get({
+        publicKey: {
+          challenge,
+          userVerification: 'required',
+          rpId: opts.rpId,
+          timeout: 60_000
+        }
+      });
+      if (!cred) return false;
+      openGate(opts.durationMs);
+      return true;
+    } catch {
+      // User cancelled or no credential — fall through to fallback.
+    }
+  }
+
+  if (opts.fallbackConfirm) {
+    const ok = await opts.fallbackConfirm();
+    if (ok) openGate(opts.durationMs);
+    return ok;
+  }
+  return false;
+}

--- a/src/lib/crypto/sign.test.ts
+++ b/src/lib/crypto/sign.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest';
+import { chooseAlgorithm, algoParams, resetAlgorithmCache } from './algorithm';
+import { signCanonical, bodyForSigning } from './sign';
+import { verifySignedObject } from './verify';
+import { b64urlEncode } from './b64';
+
+async function makeKeyPair() {
+  resetAlgorithmCache();
+  const algo = await chooseAlgorithm();
+  const kp = (await crypto.subtle.generateKey(
+    algoParams(algo) as Algorithm,
+    true, // extractable so tests can re-import the public key
+    ['sign', 'verify']
+  )) as CryptoKeyPair;
+  const spki = await crypto.subtle.exportKey('spki', kp.publicKey);
+  return { algo, kp, devicePubB64: b64urlEncode(spki) };
+}
+
+describe('signCanonical / verifySignedObject round-trip', () => {
+  it('signs and verifies a minimal event', async () => {
+    const { algo, kp, devicePubB64 } = await makeKeyPair();
+    const partial = {
+      v: 1 as const,
+      actor: 'user-1',
+      device: devicePubB64,
+      action: 'test.action',
+      subject: { type: 'test', id: 'subj-1' },
+      parents: [] as string[],
+      ts: 1700000000000,
+      nonce: 'aaaa'
+    };
+    const { sig, id } = await signCanonical(partial, kp.privateKey, algo);
+    const ev = { ...partial, sig, id };
+
+    const res = await verifySignedObject(ev, async () => ({ key: kp.publicKey, algo }));
+    expect(res.ok).toBe(true);
+  });
+
+  it('rejects tampered body', async () => {
+    const { algo, kp, devicePubB64 } = await makeKeyPair();
+    const partial = {
+      v: 1 as const,
+      actor: 'user-1',
+      device: devicePubB64,
+      action: 'test.action',
+      subject: { type: 'test', id: 'subj-1' },
+      parents: [] as string[],
+      ts: 1700000000000,
+      nonce: 'aaaa'
+    };
+    const { sig, id } = await signCanonical(partial, kp.privateKey, algo);
+    const tampered = { ...partial, sig, id, ts: partial.ts + 1 };
+
+    const res = await verifySignedObject(tampered, async () => ({ key: kp.publicKey, algo }));
+    expect(res.ok).toBe(false);
+  });
+
+  it('rejects wrong public key', async () => {
+    const { algo, kp, devicePubB64 } = await makeKeyPair();
+    const other = await makeKeyPair();
+    const partial = {
+      v: 1 as const,
+      actor: 'user-1',
+      device: devicePubB64,
+      action: 'test.action',
+      subject: { type: 'test', id: 'subj-1' },
+      parents: [] as string[],
+      ts: 1700000000000,
+      nonce: 'aaaa'
+    };
+    const { sig, id } = await signCanonical(partial, kp.privateKey, algo);
+    const ev = { ...partial, sig, id };
+
+    const res = await verifySignedObject(ev, async () => ({ key: other.kp.publicKey, algo: other.algo }));
+    expect(res.ok).toBe(false);
+  });
+
+  it('rejects unknown device (resolver returns null)', async () => {
+    const { algo, kp, devicePubB64 } = await makeKeyPair();
+    const partial = {
+      v: 1 as const,
+      actor: 'user-1',
+      device: devicePubB64,
+      action: 'test.action',
+      subject: { type: 'test', id: 'subj-1' },
+      parents: [] as string[],
+      ts: 1700000000000,
+      nonce: 'aaaa'
+    };
+    const { sig, id } = await signCanonical(partial, kp.privateKey, algo);
+    const ev = { ...partial, sig, id };
+
+    const res = await verifySignedObject(ev, async () => null);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toBe('unknown_or_revoked_device');
+  });
+
+  it('rejects tampered id', async () => {
+    const { algo, kp, devicePubB64 } = await makeKeyPair();
+    const partial = {
+      v: 1 as const,
+      actor: 'user-1',
+      device: devicePubB64,
+      action: 'test.action',
+      subject: { type: 'test', id: 'subj-1' },
+      parents: [] as string[],
+      ts: 1700000000000,
+      nonce: 'aaaa'
+    };
+    const { sig, id } = await signCanonical(partial, kp.privateKey, algo);
+    void id;
+    const ev = { ...partial, sig, id: 'AAAA' };
+
+    const res = await verifySignedObject(ev, async () => ({ key: kp.publicKey, algo }));
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toBe('bad_id');
+  });
+});
+
+describe('bodyForSigning', () => {
+  it('strips id and sig', () => {
+    const body = bodyForSigning({ id: 'x', sig: 'y', a: 1 } as { id: string; sig: string; a: number });
+    expect(body).toEqual({ a: 1 });
+  });
+});

--- a/src/lib/crypto/sign.ts
+++ b/src/lib/crypto/sign.ts
@@ -1,0 +1,37 @@
+import { signParams, type SigAlgo } from './algorithm';
+import { canonicalize, canonicalBytes, type JsonValue } from './canonical';
+import { b64urlEncode } from './b64';
+
+export type Unsigned<T> = Omit<T, 'id' | 'sig'>;
+
+export async function signCanonical(
+  body: JsonValue,
+  privateKey: CryptoKey,
+  algo: SigAlgo
+): Promise<{ sig: string; id: string }> {
+  const bodyBytes = canonicalBytes(body);
+  const sigBuf = await crypto.subtle.sign(signParams(algo) as Algorithm, privateKey, bodyBytes);
+  const sig = b64urlEncode(sigBuf);
+
+  // id = sha256 of canonical(body + sig). This binds the id to the signature,
+  // so any tamper of either invalidates it.
+  const withSig = { ...(body as Record<string, JsonValue>), sig };
+  const idBuf = await crypto.subtle.digest('SHA-256', canonicalBytes(withSig));
+  const id = b64urlEncode(idBuf);
+  return { sig, id };
+}
+
+export function bodyForSigning<T extends { id?: string; sig?: string }>(ev: T): JsonValue {
+  const { id: _id, sig: _sig, ...rest } = ev;
+  void _id;
+  void _sig;
+  return rest as unknown as JsonValue;
+}
+
+export function bodyWithSig<T extends { id?: string; sig: string }>(ev: T): JsonValue {
+  const { id: _id, ...rest } = ev;
+  void _id;
+  return rest as unknown as JsonValue;
+}
+
+export { canonicalize };

--- a/src/lib/crypto/swSign.ts
+++ b/src/lib/crypto/swSign.ts
@@ -1,0 +1,141 @@
+// Service-worker-compatible signing path. Uses only globally-available APIs
+// (crypto.subtle, indexedDB) — no `browser` import or DOM-only helpers.
+//
+// The SW is intentionally the single owner of the user's non-extractable
+// private CryptoKey: only the SW reads it from IDB and only the SW signs.
+
+import { signCanonical } from './sign';
+import { canonicalize } from './canonical';
+import type { ConsentEvent } from '$lib/consent/event';
+
+type IdentityRow = {
+  id: 'self';
+  userId: string;
+  algo: 'Ed25519' | 'ECDSA-P256';
+  privateKey: CryptoKey;
+  publicKey: CryptoKey;
+  pubSpki: ArrayBuffer;
+  devicePubB64: string;
+  createdAt: number;
+};
+
+const DB_NAME = 'freemates-crypto';
+const DB_VERSION = 1;
+
+function openDb(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const r = indexedDB.open(DB_NAME, DB_VERSION);
+    r.onsuccess = () => resolve(r.result);
+    r.onerror = () => reject(r.error);
+  });
+}
+
+async function getIdentity(): Promise<IdentityRow | undefined> {
+  const db = await openDb();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction('identity', 'readonly');
+    const req = tx.objectStore('identity').get('self');
+    req.onsuccess = () => resolve(req.result as IdentityRow | undefined);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+async function addPending(ev: ConsentEvent): Promise<void> {
+  const db = await openDb();
+  await new Promise<void>((resolve, reject) => {
+    const tx = db.transaction('pendingSync', 'readwrite');
+    const req = tx.objectStore('pendingSync').put(ev);
+    req.onsuccess = () => resolve();
+    req.onerror = () => reject(req.error);
+  });
+}
+
+async function listPending(): Promise<ConsentEvent[]> {
+  const db = await openDb();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction('pendingSync', 'readonly');
+    const req = tx.objectStore('pendingSync').getAll();
+    req.onsuccess = () => resolve(req.result as ConsentEvent[]);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+async function removePending(id: string): Promise<void> {
+  const db = await openDb();
+  await new Promise<void>((resolve, reject) => {
+    const tx = db.transaction('pendingSync', 'readwrite');
+    const req = tx.objectStore('pendingSync').delete(id);
+    req.onsuccess = () => resolve();
+    req.onerror = () => reject(req.error);
+  });
+}
+
+export async function signEventInSw(partial: {
+  v: 1;
+  actor: string;
+  action: string;
+  subject: { type: string; id: string };
+  predicate?: Record<string, unknown>;
+  parents?: string[];
+  ts?: number;
+  nonce?: string;
+}): Promise<{ ok: false; reason: string } | { ok: true; event: ConsentEvent }> {
+  const identity = await getIdentity();
+  if (!identity) return { ok: false, reason: 'no_identity' };
+  if (identity.userId !== partial.actor) {
+    return { ok: false, reason: 'actor_mismatch' };
+  }
+
+  const body = {
+    v: 1 as const,
+    actor: partial.actor,
+    device: identity.devicePubB64,
+    action: partial.action,
+    subject: partial.subject,
+    predicate: partial.predicate,
+    parents: partial.parents ?? [],
+    ts: partial.ts ?? Date.now(),
+    nonce: partial.nonce ?? (() => {
+      const buf = new Uint8Array(16);
+      crypto.getRandomValues(buf);
+      return btoa(String.fromCharCode(...buf))
+        .replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+    })()
+  };
+  const { sig, id } = await signCanonical(
+    body as unknown as import('./canonical').JsonValue,
+    identity.privateKey,
+    identity.algo
+  );
+  const event = { ...body, sig, id } as ConsentEvent;
+  await addPending(event);
+  return { ok: true, event };
+}
+
+export async function flushPending(endpoint = '/api/consent/events'): Promise<{ sent: number; failed: number }> {
+  const pending = await listPending();
+  let sent = 0;
+  let failed = 0;
+  for (const ev of pending) {
+    try {
+      const res = await fetch(endpoint, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ event: ev })
+      });
+      if (res.ok) {
+        await removePending(ev.id);
+        sent++;
+      } else {
+        failed++;
+      }
+    } catch {
+      failed++;
+    }
+  }
+  return { sent, failed };
+}
+
+// Re-export so SW can ergonomically import a single module.
+export { canonicalize };

--- a/src/lib/crypto/verify.ts
+++ b/src/lib/crypto/verify.ts
@@ -1,0 +1,43 @@
+import { signParams, type SigAlgo } from './algorithm';
+import { canonicalBytes } from './canonical';
+import { b64urlDecode, b64urlEncode } from './b64';
+import { bodyForSigning, bodyWithSig } from './sign';
+
+export type VerifyResult =
+  | { ok: true; reason?: undefined }
+  | { ok: false; reason: string };
+
+export type PubKeyResolver = (actor: string, devicePubB64: string) =>
+  Promise<{ key: CryptoKey; algo: SigAlgo } | null>;
+
+export async function verifySignedObject<T extends { id: string; sig: string; actor: string; device: string }>(
+  ev: T,
+  resolve: PubKeyResolver
+): Promise<VerifyResult> {
+  const match = await resolve(ev.actor, ev.device);
+  if (!match) return { ok: false, reason: 'unknown_or_revoked_device' };
+
+  let sigBytes: Uint8Array<ArrayBuffer>;
+  try {
+    sigBytes = b64urlDecode(ev.sig) as Uint8Array<ArrayBuffer>;
+  } catch {
+    return { ok: false, reason: 'bad_sig_encoding' };
+  }
+
+  const body = bodyForSigning(ev);
+  const bodyBytes = canonicalBytes(body);
+
+  let ok: boolean;
+  try {
+    ok = await crypto.subtle.verify(signParams(match.algo) as Algorithm, match.key, sigBytes, bodyBytes);
+  } catch (e) {
+    return { ok: false, reason: 'verify_threw: ' + (e as Error).message };
+  }
+  if (!ok) return { ok: false, reason: 'bad_signature' };
+
+  const idBuf = await crypto.subtle.digest('SHA-256', canonicalBytes(bodyWithSig(ev)));
+  const expectedId = b64urlEncode(idBuf);
+  if (expectedId !== ev.id) return { ok: false, reason: 'bad_id' };
+
+  return { ok: true };
+}

--- a/src/lib/server/consent/integration.test.ts
+++ b/src/lib/server/consent/integration.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { chooseAlgorithm, algoParams } from '$lib/crypto/algorithm';
+import { signCanonical } from '$lib/crypto/sign';
+import { b64urlEncode } from '$lib/crypto/b64';
+import { consentStore } from './store';
+import { verifyConsentEvent } from './verifyServerSide';
+import type { ConsentEvent } from '$lib/consent/event';
+
+async function bootstrapIdentity(userId: string, label = 'test') {
+  const algo = await chooseAlgorithm();
+  const kp = (await crypto.subtle.generateKey(
+    algoParams(algo) as Algorithm, true, ['sign', 'verify']
+  )) as CryptoKeyPair;
+  const spki = await crypto.subtle.exportKey('spki', kp.publicKey);
+  const devicePubB64 = b64urlEncode(spki);
+  consentStore.putKey({
+    userId,
+    devicePubB64,
+    algo,
+    pubSpkiB64: devicePubB64, // SPKI bytes; reusing the b64 encoding
+    label,
+    addedAt: Date.now()
+  });
+  return { algo, kp, devicePubB64 };
+}
+
+async function buildEvent(
+  identity: Awaited<ReturnType<typeof bootstrapIdentity>>,
+  partial: { actor: string; action: string; subject: { type: string; id: string }; predicate?: Record<string, unknown>; parents?: string[]; ts?: number }
+): Promise<ConsentEvent> {
+  const body = {
+    v: 1 as const,
+    actor: partial.actor,
+    device: identity.devicePubB64,
+    action: partial.action,
+    subject: partial.subject,
+    predicate: partial.predicate,
+    parents: partial.parents ?? [],
+    ts: partial.ts ?? Date.now(),
+    nonce: b64urlEncode(crypto.getRandomValues(new Uint8Array(16)))
+  };
+  const { sig, id } = await signCanonical(
+    body as unknown as import('$lib/crypto/canonical').JsonValue,
+    identity.kp.privateKey,
+    identity.algo
+  );
+  return { ...body, sig, id } as ConsentEvent;
+}
+
+describe('end-to-end consent flow (server-side store)', () => {
+  beforeEach(() => consentStore._reset());
+
+  it('registers a key, accepts a signed event, retrieves it', async () => {
+    const id = await bootstrapIdentity('user-A');
+    const ev = await buildEvent(id, {
+      actor: 'user-A',
+      action: 'tosplit.create',
+      subject: { type: 'tosplit', id: 'ts-XYZ' },
+      predicate: { halukas: [] }
+    });
+
+    const v = await verifyConsentEvent(ev);
+    expect(v.ok).toBe(true);
+
+    consentStore.putEvent(ev);
+    const got = consentStore.getEvent(ev.id);
+    expect(got?.id).toBe(ev.id);
+
+    const list = consentStore.eventsForSubject('tosplit', 'ts-XYZ');
+    expect(list.length).toBe(1);
+  });
+
+  it('rejects an event signed by an unregistered device', async () => {
+    const id = await bootstrapIdentity('user-A');
+    const ev = await buildEvent(id, {
+      actor: 'user-B', // mismatched actor — no key registered for user-B
+      action: 'tosplit.create',
+      subject: { type: 'tosplit', id: 'ts-XYZ' }
+    });
+    const v = await verifyConsentEvent(ev);
+    expect(v.ok).toBe(false);
+  });
+
+  it('rejects an event whose body was tampered after signing', async () => {
+    const id = await bootstrapIdentity('user-A');
+    const ev = await buildEvent(id, {
+      actor: 'user-A',
+      action: 'tosplit.create',
+      subject: { type: 'tosplit', id: 'ts-XYZ' }
+    });
+    const tampered: ConsentEvent = { ...ev, ts: ev.ts + 1 };
+    const v = await verifyConsentEvent(tampered);
+    expect(v.ok).toBe(false);
+  });
+
+  it('two members vote on a tosplit — both verify independently', async () => {
+    const a = await bootstrapIdentity('user-A');
+    const b = await bootstrapIdentity('user-B');
+    const createEv = await buildEvent(a, {
+      actor: 'user-A',
+      action: 'tosplit.create',
+      subject: { type: 'tosplit', id: 'ts-1' },
+      predicate: { halukas: [{ to: 'user-B', amount: 100 }] }
+    });
+    const voteA = await buildEvent(a, {
+      actor: 'user-A',
+      action: 'tosplit.vote',
+      subject: { type: 'tosplit', id: 'ts-1' },
+      predicate: { what: true },
+      parents: [createEv.id]
+    });
+    const voteB = await buildEvent(b, {
+      actor: 'user-B',
+      action: 'tosplit.vote',
+      subject: { type: 'tosplit', id: 'ts-1' },
+      predicate: { what: true },
+      parents: [createEv.id]
+    });
+    for (const ev of [createEv, voteA, voteB]) {
+      const v = await verifyConsentEvent(ev);
+      expect(v.ok, `event ${ev.action} should verify`).toBe(true);
+      consentStore.putEvent(ev);
+    }
+    const list = consentStore.eventsForSubject('tosplit', 'ts-1');
+    expect(list.length).toBe(3);
+  });
+});

--- a/src/lib/server/consent/store.ts
+++ b/src/lib/server/consent/store.ts
@@ -1,0 +1,75 @@
+// Server-side mirror of consent events and public keys.
+//
+// Phase 0 uses an in-memory store. Phase 1+ will swap the impl for a Strapi-backed
+// repository (collections: consent-event, user-key). The interface here is the
+// integration seam — wire Strapi behind these functions, not in the route handlers.
+
+import type { ConsentEvent, DeviceCert } from '$lib/consent/event';
+
+export type StoredPubKey = {
+  userId: string;
+  devicePubB64: string;        // primary key
+  algo: 'Ed25519' | 'ECDSA-P256';
+  pubSpkiB64: string;          // base64url-encoded SPKI bytes
+  label: string;
+  cert?: DeviceCert;           // null for self-cert / TOFU first device
+  revokedAt?: number;
+  addedAt: number;
+};
+
+const events = new Map<string, ConsentEvent>();           // id -> event
+const eventsBySubject = new Map<string, Set<string>>();   // `${type}:${id}` -> event ids
+const keysByUser = new Map<string, Map<string, StoredPubKey>>(); // userId -> devicePubB64 -> key
+
+function subjectKey(type: string, id: string) {
+  return `${type}:${id}`;
+}
+
+export const consentStore = {
+  putEvent(ev: ConsentEvent) {
+    if (events.has(ev.id)) return false;
+    events.set(ev.id, ev);
+    const k = subjectKey(ev.subject.type, ev.subject.id);
+    const set = eventsBySubject.get(k) ?? new Set();
+    set.add(ev.id);
+    eventsBySubject.set(k, set);
+    return true;
+  },
+
+  getEvent(id: string) {
+    return events.get(id);
+  },
+
+  eventsForSubject(type: string, id: string): ConsentEvent[] {
+    const ids = eventsBySubject.get(subjectKey(type, id));
+    if (!ids) return [];
+    const out: ConsentEvent[] = [];
+    for (const evId of ids) {
+      const e = events.get(evId);
+      if (e) out.push(e);
+    }
+    return out;
+  },
+
+  putKey(k: StoredPubKey) {
+    const m = keysByUser.get(k.userId) ?? new Map<string, StoredPubKey>();
+    m.set(k.devicePubB64, k);
+    keysByUser.set(k.userId, m);
+  },
+
+  getKey(userId: string, devicePubB64: string): StoredPubKey | undefined {
+    return keysByUser.get(userId)?.get(devicePubB64);
+  },
+
+  getKeysForUser(userId: string): StoredPubKey[] {
+    const m = keysByUser.get(userId);
+    return m ? [...m.values()] : [];
+  },
+
+  // Test helper
+  _reset() {
+    events.clear();
+    eventsBySubject.clear();
+    keysByUser.clear();
+  }
+};

--- a/src/lib/server/consent/verifyServerSide.ts
+++ b/src/lib/server/consent/verifyServerSide.ts
@@ -1,0 +1,33 @@
+import { webcrypto } from 'node:crypto';
+import { algoParams } from '$lib/crypto/algorithm';
+import { verifySignedObject, type PubKeyResolver } from '$lib/crypto/verify';
+import type { ConsentEvent } from '$lib/consent/event';
+import { consentStore } from './store';
+import { b64urlDecode } from '$lib/crypto/b64';
+
+// SvelteKit server runs in Node; ensure crypto.subtle is available globally.
+// (Node 18+ exposes it; on older versions we'd fall back to webcrypto.subtle.)
+const subtle = (globalThis.crypto?.subtle ?? webcrypto.subtle) as SubtleCrypto;
+if (!globalThis.crypto) {
+  // @ts-expect-error — augmenting globalThis for verifySignedObject
+  globalThis.crypto = webcrypto;
+}
+
+export const resolveFromStore: PubKeyResolver = async (actor, devicePubB64) => {
+  const stored = consentStore.getKey(actor, devicePubB64);
+  if (!stored) return null;
+  if (stored.revokedAt) return null;
+
+  const spkiBytes = b64urlDecode(stored.pubSpkiB64);
+  const params = algoParams(stored.algo) as AlgorithmIdentifier;
+  const buf = spkiBytes.buffer.slice(
+    spkiBytes.byteOffset,
+    spkiBytes.byteOffset + spkiBytes.byteLength
+  ) as ArrayBuffer;
+  const key = await subtle.importKey('spki', buf, params, true, ['verify']);
+  return { key, algo: stored.algo };
+};
+
+export async function verifyConsentEvent(ev: ConsentEvent) {
+  return verifySignedObject(ev, resolveFromStore);
+}

--- a/src/routes/api/consent/events/+server.ts
+++ b/src/routes/api/consent/events/+server.ts
@@ -1,0 +1,31 @@
+import { json, error } from '@sveltejs/kit';
+import type { RequestHandler } from '@sveltejs/kit';
+import { isConsentEventShape, type ConsentEvent } from '$lib/consent/event';
+import { verifyConsentEvent } from '$lib/server/consent/verifyServerSide';
+import { consentStore } from '$lib/server/consent/store';
+
+export const POST: RequestHandler = async ({ request, cookies }) => {
+  // JWT cookie gates abuse, but the signature is the real authentication.
+  if (!cookies.get('jwt')) throw error(401, 'Unauthorized');
+
+  const body = await request.json();
+  const ev = body?.event;
+  if (!isConsentEventShape(ev)) throw error(400, 'bad event shape');
+
+  const v = await verifyConsentEvent(ev as ConsentEvent);
+  if (!v.ok) throw error(400, `verify failed: ${v.reason}`);
+
+  const added = consentStore.putEvent(ev as ConsentEvent);
+  return json({ ok: true, deduped: !added, id: (ev as ConsentEvent).id });
+};
+
+export const GET: RequestHandler = async ({ url, cookies }) => {
+  if (!cookies.get('jwt')) throw error(401, 'Unauthorized');
+
+  const subjectType = url.searchParams.get('subjectType');
+  const subjectId = url.searchParams.get('subjectId');
+  if (!subjectType || !subjectId) throw error(400, 'subjectType and subjectId required');
+
+  const events = consentStore.eventsForSubject(subjectType, subjectId);
+  return json({ ok: true, events });
+};

--- a/src/routes/api/consent/events/[id]/+server.ts
+++ b/src/routes/api/consent/events/[id]/+server.ts
@@ -1,0 +1,10 @@
+import { json, error } from '@sveltejs/kit';
+import type { RequestHandler } from '@sveltejs/kit';
+import { consentStore } from '$lib/server/consent/store';
+
+export const GET: RequestHandler = async ({ params, cookies }) => {
+  if (!cookies.get('jwt')) throw error(401, 'Unauthorized');
+  const ev = consentStore.getEvent(params.id!);
+  if (!ev) throw error(404, 'not found');
+  return json({ ok: true, event: ev });
+};

--- a/src/routes/api/consent/keys/[userId]/+server.ts
+++ b/src/routes/api/consent/keys/[userId]/+server.ts
@@ -1,0 +1,21 @@
+import { json, error } from '@sveltejs/kit';
+import type { RequestHandler } from '@sveltejs/kit';
+import { consentStore } from '$lib/server/consent/store';
+
+export const GET: RequestHandler = async ({ params, cookies }) => {
+  if (!cookies.get('jwt')) throw error(401, 'Unauthorized');
+  const keys = consentStore.getKeysForUser(params.userId!);
+  // Strip the cert payload — not all callers need it. Pub key bytes are public.
+  return json({
+    ok: true,
+    keys: keys.map((k) => ({
+      userId: k.userId,
+      devicePubB64: k.devicePubB64,
+      algo: k.algo,
+      pubSpkiB64: k.pubSpkiB64,
+      label: k.label,
+      revokedAt: k.revokedAt ?? null,
+      addedAt: k.addedAt
+    }))
+  });
+};

--- a/src/routes/api/consent/keys/register/+server.ts
+++ b/src/routes/api/consent/keys/register/+server.ts
@@ -1,0 +1,44 @@
+import { json, error } from '@sveltejs/kit';
+import type { RequestHandler } from '@sveltejs/kit';
+import { consentStore, type StoredPubKey } from '$lib/server/consent/store';
+
+// POST /api/consent/keys/register
+// body: { userId, devicePubB64, algo, pubSpkiB64, label, cert? }
+//
+// First device for a user is accepted on first-touch (TOFU) — out-of-band email
+// confirmation is expected at the application level. Subsequent devices must
+// include a DeviceCert signed by an existing trusted device (verification is
+// added in Phase 2).
+export const POST: RequestHandler = async ({ request, cookies }) => {
+  if (!cookies.get('jwt')) throw error(401, 'Unauthorized');
+  const userId = cookies.get('id');
+  if (!userId) throw error(401, 'no user id in session');
+
+  const body = await request.json();
+  if (!body || body.userId !== userId) {
+    throw error(403, 'userId in body must match session');
+  }
+  const { devicePubB64, algo, pubSpkiB64, label, cert } = body as {
+    devicePubB64?: unknown; algo?: unknown; pubSpkiB64?: unknown;
+    label?: unknown; cert?: unknown;
+  };
+  if (typeof devicePubB64 !== 'string' ||
+      (algo !== 'Ed25519' && algo !== 'ECDSA-P256') ||
+      typeof pubSpkiB64 !== 'string' ||
+      typeof label !== 'string') {
+    throw error(400, 'bad shape');
+  }
+
+  // Phase 2 will verify `cert` chain here.
+  const stored: StoredPubKey = {
+    userId,
+    devicePubB64,
+    algo,
+    pubSpkiB64,
+    label,
+    cert: cert as StoredPubKey['cert'],
+    addedAt: Date.now()
+  };
+  consentStore.putKey(stored);
+  return json({ ok: true });
+};

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -2,6 +2,7 @@
 
 //TODO: push nutifiction, english menifast
 import { build, files, version } from '$service-worker';
+import { signEventInSw, flushPending } from '$lib/crypto/swSign';
 
 // Create a unique cache name for this deployment
 const CACHE = `cache-${version}`;
@@ -85,6 +86,30 @@ self.addEventListener('notificationclick', function(event) {
           });*/
       })
   );
+});
+
+// Consent signing: a single-writer endpoint that signs an event with the
+// non-extractable private key kept in the freemates-crypto IDB. UI tabs pass
+// MessageChannel ports so the reply is delivered back to the originator.
+self.addEventListener('message', (ev) => {
+  const data = ev.data;
+  if (!data || data.type !== 'consent.sign') return;
+  const port = ev.ports && ev.ports[0];
+  ev.waitUntil((async () => {
+    try {
+      const res = await signEventInSw(data.payload);
+      if (port) port.postMessage(res);
+      if (res.ok && self.registration && self.registration.sync) {
+        try { await self.registration.sync.register('consent-sync'); } catch (e) { void e; }
+      }
+    } catch (e) {
+      if (port) port.postMessage({ ok: false, reason: 'sw_threw: ' + (e && e.message) });
+    }
+  })());
+});
+
+self.addEventListener('sync', (ev) => {
+  if (ev.tag === 'consent-sync') ev.waitUntil(flushPending());
 });
 
 self.addEventListener('fetch', (event) => {


### PR DESCRIPTION
Add the foundation for cryptographically signed consent events: each user is
the source of truth for their own data, the server is a verifying mirror.

- src/lib/crypto: Ed25519 (ECDSA-P256 fallback) sign/verify with
  RFC 8785 JCS canonicalization, non-extractable keys in IndexedDB,
  optional WebAuthn gate before signing batches
- src/lib/consent: ConsentEvent DAG, reducers, pure projection of events
  to ProjectState, sign+publish helper for UI use
- src/lib/server/consent: in-memory mirror with seam for Strapi wiring,
  Node-side signature verifier
- /api/consent/{events,keys}: SvelteKit endpoints for publishing pubkeys
  and shipping signed events, JWT cookie gates abuse, signature is real auth
- service-worker.js: consent.sign message handler (single owner of the
  private key) plus background sync flush

25 unit + integration tests cover canonicalization, round-trip
sign/verify, tampered-body rejection, unknown-device rejection, tosplit
unanimity, revote, member leave, DAG topo-sort commutativity, and full
two-member tosplit voting end-to-end through the server mirror.

Phase 1+ will integrate this with createTosplit/addVote in shadow mode.

https://claude.ai/code/session_01XxJMiBkwycgHdWTtCaNXVd