### PR TITLE
feat(resources): monthly recurring expense resources end-to-end

### DIFF
--- a/src/generated/STRAPI_SCHEMA_REFERENCE.md
+++ b/src/generated/STRAPI_SCHEMA_REFERENCE.md
@@ -1,6 +1,6 @@
 # Strapi GraphQL Schema Reference
 > Auto-generated from `src/generated/graphql.ts`
-> Last updated: 2026-06-09
+> Last updated: 2026-06-17
 > Source: `codegen.ts` → `http://localhost:1337/graphql`
 
 This file provides a compact reference of all types available from the Strapi backend.
@@ -23,7 +23,7 @@ import type { StrapiEntity, StrapiCollection, StrapiMedia } from '$lib/types/str
 
 ---
 
-## 🏗️ Content Type Entities (107)
+## 🏗️ Content Type Entities (108)
 
 These are the main content types in the Strapi backend.
 
@@ -456,19 +456,27 @@ These are the main content types in the Strapi backend.
 ### Haluka
 | Field | Type |
 |-------|------|
+| `adjustDirection` | `Maybe<Enum_Haluka_Adjustdirection>` |
+| `adjustReason` | `Maybe<Scalars['String']['output']>` |
 | `amount` | `Maybe<Scalars['Float']['output']>` |
+| `autoApproved` | `Maybe<Scalars['Boolean']['output']>` |
 | `chatre` | `Maybe<Array<Maybe<ComponentProjectsChatre>>>` |
 | `confirmed` | `Scalars['Boolean']['output']` |
 | `createdAt` | `Maybe<Scalars['DateTime']['output']>` |
 | `forum` | `Maybe<ForumEntityResponse>` |
+| `isSiteShare` | `Maybe<Scalars['Boolean']['output']>` |
 | `locale` | `Maybe<Scalars['String']['output']>` |
 | `localizations` | `Maybe<HalukaRelationResponseCollection>` |
 | `matbea` | `Maybe<MatbeaEntityResponse>` |
 | `project` | `Maybe<ProjectEntityResponse>` |
+| `proposedAmount` | `Maybe<Scalars['Float']['output']>` |
 | `publishedAt` | `Maybe<Scalars['DateTime']['output']>` |
 | `ratson_share` | `Maybe<RatsonShareEntityResponse>` |
+| `recive_project` | `Maybe<ProjectEntityResponse>` |
 | `senderconf` | `Maybe<Scalars['Boolean']['output']>` |
 | `sheirut` | `Maybe<SheirutEntityResponse>` |
+| `site_share_contribution` | `Maybe<SiteShareContributionEntityResponse>` |
+| `source_tosplit` | `Maybe<TosplitEntityResponse>` |
 | `tosplit` | `Maybe<TosplitEntityResponse>` |
 | `updatedAt` | `Maybe<Scalars['DateTime']['output']>` |
 | `userrecive` | `Maybe<UsersPermissionsUserEntityResponse>` |
@@ -955,6 +963,7 @@ These are the main content types in the Strapi backend.
 | `createSheirutpend` | `Maybe<SheirutpendEntityResponse>` |
 | `createSheirutpendLocalization` | `Maybe<SheirutpendEntityResponse>` |
 | `createSidur` | `Maybe<SidurEntityResponse>` |
+| `createSiteShareContribution` | `Maybe<SiteShareContributionEntityResponse>` |
 | `createSkill` | `Maybe<SkillEntityResponse>` |
 | `createSkillLocalization` | `Maybe<SkillEntityResponse>` |
 | `createSolution` | `Maybe<SolutionEntityResponse>` |
@@ -1057,6 +1066,7 @@ These are the main content types in the Strapi backend.
 | `deleteSheirutnego` | `Maybe<SheirutnegoEntityResponse>` |
 | `deleteSheirutpend` | `Maybe<SheirutpendEntityResponse>` |
 | `deleteSidur` | `Maybe<SidurEntityResponse>` |
+| `deleteSiteShareContribution` | `Maybe<SiteShareContributionEntityResponse>` |
 | `deleteSkill` | `Maybe<SkillEntityResponse>` |
 | `deleteSolution` | `Maybe<SolutionEntityResponse>` |
 | `deleteSp` | `Maybe<SpEntityResponse>` |
@@ -1158,6 +1168,7 @@ These are the main content types in the Strapi backend.
 | `updateSheirutnego` | `Maybe<SheirutnegoEntityResponse>` |
 | `updateSheirutpend` | `Maybe<SheirutpendEntityResponse>` |
 | `updateSidur` | `Maybe<SidurEntityResponse>` |
+| `updateSiteShareContribution` | `Maybe<SiteShareContributionEntityResponse>` |
 | `updateSkill` | `Maybe<SkillEntityResponse>` |
 | `updateSolution` | `Maybe<SolutionEntityResponse>` |
 | `updateSp` | `Maybe<SpEntityResponse>` |
@@ -1212,6 +1223,7 @@ These are the main content types in the Strapi backend.
 | Field | Type |
 |-------|------|
 | `createdAt` | `Maybe<Scalars['DateTime']['output']>` |
+| `cycleSize` | `Maybe<Scalars['Int']['output']>` |
 | `descrip` | `Maybe<Scalars['String']['output']>` |
 | `easy` | `Maybe<Scalars['Float']['output']>` |
 | `hm` | `Maybe<Scalars['Float']['output']>` |
@@ -1223,6 +1235,7 @@ These are the main content types in the Strapi backend.
 | `pmash` | `Maybe<PmashEntityResponse>` |
 | `price` | `Maybe<Scalars['Float']['output']>` |
 | `publishedAt` | `Maybe<Scalars['DateTime']['output']>` |
+| `recurring` | `Maybe<Scalars['Boolean']['output']>` |
 | `spnot` | `Maybe<Scalars['String']['output']>` |
 | `sqadualed` | `Maybe<Scalars['DateTime']['output']>` |
 | `sqadualedf` | `Maybe<Scalars['DateTime']['output']>` |
@@ -1506,6 +1519,7 @@ These are the main content types in the Strapi backend.
 | `archived` | `Scalars['Boolean']['output']` |
 | `askm` | `Maybe<AskmEntityResponse>` |
 | `createdAt` | `Maybe<Scalars['DateTime']['output']>` |
+| `cycleSize` | `Maybe<Scalars['Int']['output']>` |
 | `descrip` | `Maybe<Scalars['String']['output']>` |
 | `diun` | `Maybe<Array<Maybe<ComponentProjectsVots>>>` |
 | `easy` | `Maybe<Scalars['Float']['output']>` |
@@ -1529,6 +1543,7 @@ These are the main content types in the Strapi backend.
 | `price` | `Maybe<Scalars['Float']['output']>` |
 | `project` | `Maybe<ProjectEntityResponse>` |
 | `publishedAt` | `Maybe<Scalars['DateTime']['output']>` |
+| `recurring` | `Maybe<Scalars['Boolean']['output']>` |
 | `selfProposalUser` | `Maybe<UsersPermissionsUserEntityResponse>` |
 | `sheirut_fulfillments` | `Maybe<SheirutFulfillmentRelationResponseCollection>` |
 | `spnot` | `Maybe<Scalars['String']['output']>` |
@@ -1593,6 +1608,7 @@ These are the main content types in the Strapi backend.
 | `haamadapruvs` | `Maybe<HaamadapruvRelationResponseCollection>` |
 | `haamadas` | `Maybe<HaamadaRelationResponseCollection>` |
 | `halukas` | `Maybe<HalukaRelationResponseCollection>` |
+| `halukas_recive` | `Maybe<HalukaRelationResponseCollection>` |
 | `isMachzikim` | `Maybe<Scalars['Boolean']['output']>` |
 | `isMachzikimPublik` | `Maybe<Scalars['Boolean']['output']>` |
 | `isOt` | `Maybe<Scalars['Boolean']['output']>` |
@@ -1625,8 +1641,11 @@ These are the main content types in the Strapi backend.
 | `restime` | `Maybe<Enum_Project_Restime>` |
 | `rikmashes` | `Maybe<RikmashRelationResponseCollection>` |
 | `sales` | `Maybe<SaleRelationResponseCollection>` |
+| `sales_source` | `Maybe<SaleRelationResponseCollection>` |
 | `sheirutpends` | `Maybe<SheirutpendRelationResponseCollection>` |
 | `sheiruts` | `Maybe<SheirutRelationResponseCollection>` |
+| `sheiruts_sourced` | `Maybe<SheirutRelationResponseCollection>` |
+| `site_share_contributions` | `Maybe<SiteShareContributionRelationResponseCollection>` |
 | `sps` | `Maybe<SpRelationResponseCollection>` |
 | `tafkidims` | `Maybe<TafkidimRelationResponseCollection>` |
 | `timeToP` | `Maybe<Enum_Project_Timetop>` |
@@ -1818,6 +1837,8 @@ These are the main content types in the Strapi backend.
 | `sheiruts` | `Maybe<SheirutEntityResponseCollection>` |
 | `sidur` | `Maybe<SidurEntityResponse>` |
 | `sidurs` | `Maybe<SidurEntityResponseCollection>` |
+| `siteShareContribution` | `Maybe<SiteShareContributionEntityResponse>` |
+| `siteShareContributions` | `Maybe<SiteShareContributionEntityResponseCollection>` |
 | `skill` | `Maybe<SkillEntityResponse>` |
 | `skills` | `Maybe<SkillEntityResponseCollection>` |
 | `solution` | `Maybe<SolutionEntityResponse>` |
@@ -2035,6 +2056,7 @@ These are the main content types in the Strapi backend.
 | `finishDate` | `Maybe<Scalars['DateTime']['output']>` |
 | `in` | `Maybe<Scalars['Float']['output']>` |
 | `isMonterActive` | `Maybe<Scalars['Boolean']['output']>` |
+| `isSiteShareIncome` | `Maybe<Scalars['Boolean']['output']>` |
 | `matanot` | `Maybe<MatanotEntityResponse>` |
 | `monters` | `Maybe<MonterRelationResponseCollection>` |
 | `note` | `Maybe<Scalars['String']['output']>` |
@@ -2042,6 +2064,7 @@ These are the main content types in the Strapi backend.
 | `project` | `Maybe<ProjectEntityResponse>` |
 | `publishedAt` | `Maybe<Scalars['DateTime']['output']>` |
 | `sheiruts` | `Maybe<SheirutRelationResponseCollection>` |
+| `source_project` | `Maybe<ProjectEntityResponse>` |
 | `splited` | `Scalars['Boolean']['output']` |
 | `startDate` | `Maybe<Scalars['DateTime']['output']>` |
 | `tosplits` | `Maybe<TosplitRelationResponseCollection>` |
@@ -2078,6 +2101,7 @@ These are the main content types in the Strapi backend.
 | `iTransferedTo` | `Maybe<UsersPermissionsUserRelationResponseCollection>` |
 | `isApruved` | `Maybe<Scalars['Boolean']['output']>` |
 | `isItOnlyOneInProject` | `Maybe<Scalars['Boolean']['output']>` |
+| `isSiteShareIncome` | `Maybe<Scalars['Boolean']['output']>` |
 | `locale` | `Maybe<Scalars['String']['output']>` |
 | `localizations` | `Maybe<SheirutRelationResponseCollection>` |
 | `matanot` | `Maybe<MatanotEntityResponse>` |
@@ -2092,7 +2116,10 @@ These are the main content types in the Strapi backend.
 | `sales` | `Maybe<SaleRelationResponseCollection>` |
 | `sheirut_fulfillments` | `Maybe<SheirutFulfillmentRelationResponseCollection>` |
 | `sheirutpend` | `Maybe<SheirutpendEntityResponse>` |
+| `site_share_contributions` | `Maybe<SiteShareContributionRelationResponseCollection>` |
+| `source_project` | `Maybe<ProjectEntityResponse>` |
 | `source_proposals` | `Maybe<RatsonRelationResponseCollection>` |
+| `source_tosplit` | `Maybe<TosplitEntityResponse>` |
 | `startDate` | `Maybe<Scalars['DateTime']['output']>` |
 | `total` | `Maybe<Scalars['Float']['output']>` |
 | `updatedAt` | `Maybe<Scalars['DateTime']['output']>` |
@@ -2166,6 +2193,26 @@ These are the main content types in the Strapi backend.
 | `lemi` | `Maybe<Scalars['String']['output']>` |
 | `publishedAt` | `Maybe<Scalars['DateTime']['output']>` |
 | `updatedAt` | `Maybe<Scalars['DateTime']['output']>` |
+
+### SiteShareContribution
+| Field | Type |
+|-------|------|
+| `amount` | `Maybe<Scalars['Float']['output']>` |
+| `basisAmount` | `Maybe<Scalars['Float']['output']>` |
+| `createdAt` | `Maybe<Scalars['DateTime']['output']>` |
+| `des_status` | `Maybe<Enum_Sitesharecontribution_Des_Status>` |
+| `direction` | `Maybe<Enum_Sitesharecontribution_Direction>` |
+| `haluka` | `Maybe<HalukaEntityResponse>` |
+| `matbea` | `Maybe<MatbeaEntityResponse>` |
+| `project` | `Maybe<ProjectEntityResponse>` |
+| `proposedAmount` | `Maybe<Scalars['Float']['output']>` |
+| `publishedAt` | `Maybe<Scalars['DateTime']['output']>` |
+| `reason` | `Maybe<Scalars['String']['output']>` |
+| `recive_project` | `Maybe<ProjectEntityResponse>` |
+| `sheirut` | `Maybe<SheirutEntityResponse>` |
+| `tosplit` | `Maybe<TosplitEntityResponse>` |
+| `updatedAt` | `Maybe<Scalars['DateTime']['output']>` |
+| `users_permissions_user` | `Maybe<UsersPermissionsUserEntityResponse>` |
 
 ### Skill
 | Field | Type |
@@ -2332,6 +2379,9 @@ These are the main content types in the Strapi backend.
 | `publishedAt` | `Maybe<Scalars['DateTime']['output']>` |
 | `ratson_proposal` | `Maybe<RatsonProposalEntityResponse>` |
 | `sales` | `Maybe<SaleRelationResponseCollection>` |
+| `sheiruts` | `Maybe<SheirutRelationResponseCollection>` |
+| `siteShareHalukas` | `Maybe<HalukaRelationResponseCollection>` |
+| `site_share_contributions` | `Maybe<SiteShareContributionRelationResponseCollection>` |
 | `split_origin` | `Maybe<Enum_Tosplit_Split_Origin>` |
 | `timegrama` | `Maybe<TimegramaEntityResponse>` |
 | `updatedAt` | `Maybe<Scalars['DateTime']['output']>` |
@@ -2519,6 +2569,7 @@ These are the main content types in the Strapi backend.
 | `negotiations` | `Maybe<NegotiationRelationResponseCollection>` |
 | `negotiationsIparticipante` | `Maybe<NegotiationRelationResponseCollection>` |
 | `noMail` | `Maybe<Scalars['Boolean']['output']>` |
+| `noMoachGuide` | `Maybe<Scalars['Boolean']['output']>` |
 | `noOfHoursProject1` | `Maybe<Scalars['Float']['output']>` |
 | `onboarding_status` | `Maybe<Enum_Userspermissionsuser_Onboarding_Status>` |
 | `onboarding_track` | `Maybe<Enum_Userspermissionsuser_Onboarding_Track>` |
@@ -2551,6 +2602,7 @@ These are the main content types in the Strapi backend.
 | `sheiruts` | `Maybe<SheirutRelationResponseCollection>` |
 | `sheiruts_iCanGetMonay` | `Maybe<SheirutRelationResponseCollection>` |
 | `shekelsPerHoureProject1` | `Maybe<Scalars['Float']['output']>` |
+| `site_share_contributions` | `Maybe<SiteShareContributionRelationResponseCollection>` |
 | `skills` | `Maybe<SkillRelationResponseCollection>` |
 | `socketId` | `Maybe<Scalars['String']['output']>` |
 | `sphmin` | `Maybe<Scalars['Float']['output']>` |
@@ -3601,7 +3653,7 @@ These are Strapi components (reusable field groups).
 
 ---
 
-## 📝 Input Types (105)
+## 📝 Input Types (106)
 
 Used for creating/updating content.
 
@@ -4076,16 +4128,24 @@ Used for creating/updating content.
 ### HalukaInput
 | Field | Type |
 |-------|------|
+| `adjustDirection` | `InputMaybe<Enum_Haluka_Adjustdirection>` |
+| `adjustReason` | `InputMaybe<Scalars['String']['input']>` |
 | `amount` | `InputMaybe<Scalars['Float']['input']>` |
+| `autoApproved` | `InputMaybe<Scalars['Boolean']['input']>` |
 | `chatre` | `InputMaybe<Array<InputMaybe<ComponentProjectsChatreInput>>>` |
 | `confirmed` | `InputMaybe<Scalars['Boolean']['input']>` |
 | `forum` | `InputMaybe<Scalars['ID']['input']>` |
+| `isSiteShare` | `InputMaybe<Scalars['Boolean']['input']>` |
 | `matbea` | `InputMaybe<Scalars['ID']['input']>` |
 | `project` | `InputMaybe<Scalars['ID']['input']>` |
+| `proposedAmount` | `InputMaybe<Scalars['Float']['input']>` |
 | `publishedAt` | `InputMaybe<Scalars['DateTime']['input']>` |
 | `ratson_share` | `InputMaybe<Scalars['ID']['input']>` |
+| `recive_project` | `InputMaybe<Scalars['ID']['input']>` |
 | `senderconf` | `InputMaybe<Scalars['Boolean']['input']>` |
 | `sheirut` | `InputMaybe<Scalars['ID']['input']>` |
+| `site_share_contribution` | `InputMaybe<Scalars['ID']['input']>` |
+| `source_tosplit` | `InputMaybe<Scalars['ID']['input']>` |
 | `tosplit` | `InputMaybe<Scalars['ID']['input']>` |
 | `userrecive` | `InputMaybe<Scalars['ID']['input']>` |
 | `usersend` | `InputMaybe<Scalars['ID']['input']>` |
@@ -4553,6 +4613,7 @@ Used for creating/updating content.
 ### NegoMashInput
 | Field | Type |
 |-------|------|
+| `cycleSize` | `InputMaybe<Scalars['Int']['input']>` |
 | `descrip` | `InputMaybe<Scalars['String']['input']>` |
 | `easy` | `InputMaybe<Scalars['Float']['input']>` |
 | `hm` | `InputMaybe<Scalars['Float']['input']>` |
@@ -4564,6 +4625,7 @@ Used for creating/updating content.
 | `pmash` | `InputMaybe<Scalars['ID']['input']>` |
 | `price` | `InputMaybe<Scalars['Float']['input']>` |
 | `publishedAt` | `InputMaybe<Scalars['DateTime']['input']>` |
+| `recurring` | `InputMaybe<Scalars['Boolean']['input']>` |
 | `spnot` | `InputMaybe<Scalars['String']['input']>` |
 | `sqadualed` | `InputMaybe<Scalars['DateTime']['input']>` |
 | `sqadualedf` | `InputMaybe<Scalars['DateTime']['input']>` |
@@ -4805,6 +4867,7 @@ Used for creating/updating content.
 |-------|------|
 | `archived` | `InputMaybe<Scalars['Boolean']['input']>` |
 | `askm` | `InputMaybe<Scalars['ID']['input']>` |
+| `cycleSize` | `InputMaybe<Scalars['Int']['input']>` |
 | `descrip` | `InputMaybe<Scalars['String']['input']>` |
 | `diun` | `InputMaybe<Array<InputMaybe<ComponentProjectsVotsInput>>>` |
 | `easy` | `InputMaybe<Scalars['Float']['input']>` |
@@ -4828,6 +4891,7 @@ Used for creating/updating content.
 | `price` | `InputMaybe<Scalars['Float']['input']>` |
 | `project` | `InputMaybe<Scalars['ID']['input']>` |
 | `publishedAt` | `InputMaybe<Scalars['DateTime']['input']>` |
+| `recurring` | `InputMaybe<Scalars['Boolean']['input']>` |
 | `selfProposalUser` | `InputMaybe<Scalars['ID']['input']>` |
 | `sheirut_fulfillments` | `InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>` |
 | `spnot` | `InputMaybe<Scalars['String']['input']>` |
@@ -4888,6 +4952,7 @@ Used for creating/updating content.
 | `haamadapruvs` | `InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>` |
 | `haamadas` | `InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>` |
 | `halukas` | `InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>` |
+| `halukas_recive` | `InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>` |
 | `isMachzikim` | `InputMaybe<Scalars['Boolean']['input']>` |
 | `isMachzikimPublik` | `InputMaybe<Scalars['Boolean']['input']>` |
 | `isOt` | `InputMaybe<Scalars['Boolean']['input']>` |
@@ -4918,8 +4983,11 @@ Used for creating/updating content.
 | `restime` | `InputMaybe<Enum_Project_Restime>` |
 | `rikmashes` | `InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>` |
 | `sales` | `InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>` |
+| `sales_source` | `InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>` |
 | `sheirutpends` | `InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>` |
 | `sheiruts` | `InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>` |
+| `sheiruts_sourced` | `InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>` |
+| `site_share_contributions` | `InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>` |
 | `sps` | `InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>` |
 | `tafkidims` | `InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>` |
 | `timeToP` | `InputMaybe<Enum_Project_Timetop>` |
@@ -5111,6 +5179,7 @@ Used for creating/updating content.
 | `finishDate` | `InputMaybe<Scalars['DateTime']['input']>` |
 | `in` | `InputMaybe<Scalars['Float']['input']>` |
 | `isMonterActive` | `InputMaybe<Scalars['Boolean']['input']>` |
+| `isSiteShareIncome` | `InputMaybe<Scalars['Boolean']['input']>` |
 | `matanot` | `InputMaybe<Scalars['ID']['input']>` |
 | `monters` | `InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>` |
 | `note` | `InputMaybe<Scalars['String']['input']>` |
@@ -5118,6 +5187,7 @@ Used for creating/updating content.
 | `project` | `InputMaybe<Scalars['ID']['input']>` |
 | `publishedAt` | `InputMaybe<Scalars['DateTime']['input']>` |
 | `sheiruts` | `InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>` |
+| `source_project` | `InputMaybe<Scalars['ID']['input']>` |
 | `splited` | `InputMaybe<Scalars['Boolean']['input']>` |
 | `startDate` | `InputMaybe<Scalars['DateTime']['input']>` |
 | `tosplits` | `InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>` |
@@ -5167,6 +5237,7 @@ Used for creating/updating content.
 | `iTransferedTo` | `InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>` |
 | `isApruved` | `InputMaybe<Scalars['Boolean']['input']>` |
 | `isItOnlyOneInProject` | `InputMaybe<Scalars['Boolean']['input']>` |
+| `isSiteShareIncome` | `InputMaybe<Scalars['Boolean']['input']>` |
 | `matanot` | `InputMaybe<Scalars['ID']['input']>` |
 | `moneyTransfered` | `InputMaybe<Scalars['Boolean']['input']>` |
 | `monters` | `InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>` |
@@ -5179,7 +5250,10 @@ Used for creating/updating content.
 | `sales` | `InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>` |
 | `sheirut_fulfillments` | `InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>` |
 | `sheirutpend` | `InputMaybe<Scalars['ID']['input']>` |
+| `site_share_contributions` | `InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>` |
+| `source_project` | `InputMaybe<Scalars['ID']['input']>` |
 | `source_proposals` | `InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>` |
+| `source_tosplit` | `InputMaybe<Scalars['ID']['input']>` |
 | `startDate` | `InputMaybe<Scalars['DateTime']['input']>` |
 | `total` | `InputMaybe<Scalars['Float']['input']>` |
 | `users_permissions_users` | `InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>` |
@@ -5225,6 +5299,24 @@ Used for creating/updating content.
 |-------|------|
 | `lemi` | `InputMaybe<Scalars['String']['input']>` |
 | `publishedAt` | `InputMaybe<Scalars['DateTime']['input']>` |
+
+### SiteShareContributionInput
+| Field | Type |
+|-------|------|
+| `amount` | `InputMaybe<Scalars['Float']['input']>` |
+| `basisAmount` | `InputMaybe<Scalars['Float']['input']>` |
+| `des_status` | `InputMaybe<Enum_Sitesharecontribution_Des_Status>` |
+| `direction` | `InputMaybe<Enum_Sitesharecontribution_Direction>` |
+| `haluka` | `InputMaybe<Scalars['ID']['input']>` |
+| `matbea` | `InputMaybe<Scalars['ID']['input']>` |
+| `project` | `InputMaybe<Scalars['ID']['input']>` |
+| `proposedAmount` | `InputMaybe<Scalars['Float']['input']>` |
+| `publishedAt` | `InputMaybe<Scalars['DateTime']['input']>` |
+| `reason` | `InputMaybe<Scalars['String']['input']>` |
+| `recive_project` | `InputMaybe<Scalars['ID']['input']>` |
+| `sheirut` | `InputMaybe<Scalars['ID']['input']>` |
+| `tosplit` | `InputMaybe<Scalars['ID']['input']>` |
+| `users_permissions_user` | `InputMaybe<Scalars['ID']['input']>` |
 
 ### SkillInput
 | Field | Type |
@@ -5390,6 +5482,9 @@ Used for creating/updating content.
 | `publishedAt` | `InputMaybe<Scalars['DateTime']['input']>` |
 | `ratson_proposal` | `InputMaybe<Scalars['ID']['input']>` |
 | `sales` | `InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>` |
+| `sheiruts` | `InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>` |
+| `siteShareHalukas` | `InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>` |
+| `site_share_contributions` | `InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>` |
 | `split_origin` | `InputMaybe<Enum_Tosplit_Split_Origin>` |
 | `timegrama` | `InputMaybe<Scalars['ID']['input']>` |
 | `vots` | `InputMaybe<Array<InputMaybe<ComponentProjectsVotsInput>>>` |
@@ -5531,6 +5626,7 @@ Used for creating/updating content.
 | `negotiations` | `InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>` |
 | `negotiationsIparticipante` | `InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>` |
 | `noMail` | `InputMaybe<Scalars['Boolean']['input']>` |
+| `noMoachGuide` | `InputMaybe<Scalars['Boolean']['input']>` |
 | `noOfHoursProject1` | `InputMaybe<Scalars['Float']['input']>` |
 | `onboarding_status` | `InputMaybe<Enum_Userspermissionsuser_Onboarding_Status>` |
 | `onboarding_track` | `InputMaybe<Enum_Userspermissionsuser_Onboarding_Track>` |
@@ -5565,6 +5661,7 @@ Used for creating/updating content.
 | `sheiruts` | `InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>` |
 | `sheiruts_iCanGetMonay` | `InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>` |
 | `shekelsPerHoureProject1` | `InputMaybe<Scalars['Float']['input']>` |
+| `site_share_contributions` | `InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>` |
 | `skills` | `InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>` |
 | `socketId` | `InputMaybe<Scalars['String']['input']>` |
 | `sphmin` | `InputMaybe<Scalars['Float']['input']>` |
@@ -5678,12 +5775,12 @@ Used for creating/updating content.
 
 ---
 
-## 🔍 Filter Input Types (94)
+## 🔍 Filter Input Types (95)
 
 Used for querying/filtering content. Each content type has a corresponding filter input.
 
 <details>
-<summary>Click to expand all 94 filter types</summary>
+<summary>Click to expand all 95 filter types</summary>
 
 #### ActFiltersInput
 Fields: `and`, `createdAt`, `dateF`, `dateS`, `des`, `forums`, `hashivut`, `id`, `isAssigned`, `link`, `locale`, `localizations`, `mesimabetahaliches`, `my`, `myIshur`, `naasa`, `negopendmissions`, `not`, `open_mission`, `or`, `partofs`, `pendm`, `project`, `publishedAt`, `shem`, `status`, `tafkidims`, `taskdis`, `timegrama`, `timers`, `updatedAt`, `userAndIshur`, `vali`, `valiIshur`
@@ -5764,7 +5861,7 @@ Fields: `amount`, `and`, `comition`, `createdAt`, `haamadapruv`, `id`, `isReturn
 Fields: `and`, `archived`, `createdAt`, `haamada`, `id`, `not`, `open_mashaabim`, `or`, `project`, `publishedAt`, `updatedAt`, `vots`
 
 #### HalukaFiltersInput
-Fields: `amount`, `and`, `chatre`, `confirmed`, `createdAt`, `forum`, `id`, `locale`, `localizations`, `matbea`, `not`, `or`, `project`, `publishedAt`, `ratson_share`, `senderconf`, `sheirut`, `tosplit`, `updatedAt`, `userrecive`, `usersend`, `ushar`, `want`
+Fields: `adjustDirection`, `adjustReason`, `amount`, `and`, `autoApproved`, `chatre`, `confirmed`, `createdAt`, `forum`, `id`, `isSiteShare`, `locale`, `localizations`, `matbea`, `not`, `or`, `project`, `proposedAmount`, `publishedAt`, `ratson_share`, `recive_project`, `senderconf`, `sheirut`, `site_share_contribution`, `source_tosplit`, `tosplit`, `updatedAt`, `userrecive`, `usersend`, `ushar`, `want`
 
 #### HatzaaFiltersInput
 Fields: `and`, `createdAt`, `id`, `noofhours`, `not`, `open_mission`, `or`, `perhoure`, `publishedAt`, `untilwhen`, `updatedAt`, `users_permissions_user`, `vots`
@@ -5824,7 +5921,7 @@ Fields: `and`, `ani`, `archived`, `createdAt`, `done`, `finish`, `id`, `mesimabe
 Fields: `acceptedAt`, `and`, `createdAt`, `des`, `fixprice`, `id`, `kindOf`, `location`, `mashaabims`, `matanot`, `matanotpend`, `missions`, `name`, `not`, `or`, `price`, `proposedHours`, `proposedPrice`, `proposedQuantity`, `publishedAt`, `quant`, `ratson_proposal`, `recipeMission`, `recipeResource`, `rejectedAt`, `updatedAt`, `votes`
 
 #### NegoMashFiltersInput
-Fields: `and`, `createdAt`, `descrip`, `easy`, `hm`, `id`, `isOriginal`, `kindOf`, `linkto`, `location`, `name`, `not`, `or`, `pmash`, `price`, `publishedAt`, `spnot`, `sqadualed`, `sqadualedf`, `updatedAt`, `users`, `users_permissions_user`
+Fields: `and`, `createdAt`, `cycleSize`, `descrip`, `easy`, `hm`, `id`, `isOriginal`, `kindOf`, `linkto`, `location`, `name`, `not`, `or`, `pmash`, `price`, `publishedAt`, `recurring`, `spnot`, `sqadualed`, `sqadualedf`, `updatedAt`, `users`, `users_permissions_user`
 
 #### NegopendmissionFiltersInput
 Fields: `acts`, `and`, `createdAt`, `date`, `dates`, `descrip`, `filds`, `hearotMeyuchadot`, `howMany`, `id`, `isMonth`, `isOriginal`, `isRishon`, `location`, `name`, `noofhours`, `not`, `open_mission`, `or`, `pendm`, `perhour`, `publishedAt`, `skills`, `tafkidims`, `total`, `updatedAt`, `users_permissions_user`, `vots`, `work_ways`
@@ -5854,13 +5951,13 @@ Fields: `and`, `available`, `createdAt`, `id`, `not`, `or`, `pgishas`, `publishe
 Fields: `and`, `approved`, `archived`, `createdAt`, `id`, `not`, `or`, `pgisha`, `updatedAt`, `users_permissions_user`
 
 #### PmashFiltersInput
-Fields: `and`, `archived`, `askm`, `createdAt`, `descrip`, `diun`, `easy`, `hm`, `id`, `isMaap`, `isMust`, `isSelfProposal`, `isYesod`, `kindOf`, `linkto`, `location`, `maap`, `mashaabim`, `mashabetahaliches`, `matanot_recipe_resources`, `name`, `nego_mashes`, `negom`, `not`, `open_mashaabim`, `or`, `partofs`, `price`, `project`, `publishedAt`, `selfProposalUser`, `sheirut_fulfillments`, `spnot`, `sqadualed`, `sqadualedf`, `timegrama`, `updatedAt`, `users`
+Fields: `and`, `archived`, `askm`, `createdAt`, `cycleSize`, `descrip`, `diun`, `easy`, `hm`, `id`, `isMaap`, `isMust`, `isSelfProposal`, `isYesod`, `kindOf`, `linkto`, `location`, `maap`, `mashaabim`, `mashabetahaliches`, `matanot_recipe_resources`, `name`, `nego_mashes`, `negom`, `not`, `open_mashaabim`, `or`, `partofs`, `price`, `project`, `publishedAt`, `recurring`, `selfProposalUser`, `sheirut_fulfillments`, `spnot`, `sqadualed`, `sqadualedf`, `timegrama`, `updatedAt`, `users`
 
 #### PositionFiltersInput
 Fields: `aiMeta`, `and`, `arguments`, `author`, `authorEmail`, `authorExternalId`, `authorType`, `clauses`, `createdAt`, `description`, `heading`, `id`, `intensity`, `isAnchor`, `kind`, `location`, `negotiation`, `not`, `or`, `order`, `pole`, `publishedAt`, `relativePlacement`, `selfPlacement`, `tags`, `updatedAt`, `voters`, `votes`
 
 #### ProjectFiltersInput
-Fields: `acts`, `addHoursManualy`, `and`, `askms`, `asks`, `askwants`, `city`, `countries`, `createdAt`, `deals`, `decisions`, `deffinitions`, `descripFor`, `discordlink`, `drivelink`, `fblink`, `finiapruvals`, `finnishedM72HForDecline`, `finnishedMAllApruve`, `finnished_missions`, `forums`, `githublink`, `haamadapruvs`, `haamadas`, `halukas`, `id`, `isMachzikim`, `isMachzikimPublik`, `isOt`, `isPlatform`, `linkToWebsite`, `locale`, `localizations`, `location`, `maaps`, `machshirs`, `mashaabims`, `mashabetahaliches`, `matanotofs`, `mesimabetahaliches`, `missions`, `newMeMissionOuto72ho`, `newOpenMissionAllApruve`, `newOpenMotoAfter72hoursWithnono`, `newmeOpenAllapruve`, `not`, `open_mashaabims`, `open_missions`, `or`, `pendms`, `pmashes`, `projectName`, `publicDescription`, `publishedAt`, `ratson_proposals`, `restime`, `rikmashes`, `sales`, `sheirutpends`, `sheiruts`, `sps`, `tafkidims`, `timeToP`, `timerOnlyTOrAlsoManuallyF`, `timers`, `tosplits`, `totalinyearone`, `totalinyearsec`, `totalmaxyearone`, `totalmaxyearsec`, `totalminyearone`, `totalminyearsec`, `twiterlink`, `updatedAt`, `user_1s`, `usersOfP`, `vallues`, `watsapplink`, `welcom_tops`, `work_ways`, `zohars`
+Fields: `acts`, `addHoursManualy`, `and`, `askms`, `asks`, `askwants`, `city`, `countries`, `createdAt`, `deals`, `decisions`, `deffinitions`, `descripFor`, `discordlink`, `drivelink`, `fblink`, `finiapruvals`, `finnishedM72HForDecline`, `finnishedMAllApruve`, `finnished_missions`, `forums`, `githublink`, `haamadapruvs`, `haamadas`, `halukas`, `halukas_recive`, `id`, `isMachzikim`, `isMachzikimPublik`, `isOt`, `isPlatform`, `linkToWebsite`, `locale`, `localizations`, `location`, `maaps`, `machshirs`, `mashaabims`, `mashabetahaliches`, `matanotofs`, `mesimabetahaliches`, `missions`, `newMeMissionOuto72ho`, `newOpenMissionAllApruve`, `newOpenMotoAfter72hoursWithnono`, `newmeOpenAllapruve`, `not`, `open_mashaabims`, `open_missions`, `or`, `pendms`, `pmashes`, `projectName`, `publicDescription`, `publishedAt`, `ratson_proposals`, `restime`, `rikmashes`, `sales`, `sales_source`, `sheirutpends`, `sheiruts`, `sheiruts_sourced`, `site_share_contributions`, `sps`, `tafkidims`, `timeToP`, `timerOnlyTOrAlsoManuallyF`, `timers`, `tosplits`, `totalinyearone`, `totalinyearsec`, `totalmaxyearone`, `totalmaxyearsec`, `totalminyearone`, `totalminyearsec`, `twiterlink`, `updatedAt`, `user_1s`, `usersOfP`, `vallues`, `watsapplink`, `welcom_tops`, `work_ways`, `zohars`
 
 #### ProviderProfileFiltersInput
 Fields: `ai_meta`, `and`, `archived`, `avg_rating`, `bio_raw`, `createdAt`, `display_name`, `id`, `lat`, `lng`, `location`, `not`, `or`, `owner_id`, `owner_type`, `pinecone_id`, `publishedAt`, `radius_km`, `updatedAt`
@@ -5884,13 +5981,13 @@ Fields: `and`, `bg`, `createdAt`, `desc`, `id`, `locale`, `localizations`, `not`
 Fields: `agprice`, `and`, `createdAt`, `cyclesCount`, `deliveries`, `firstDeliveryAt`, `haamadas`, `hm`, `id`, `isMust`, `isYesod`, `kindOf`, `lastDeliveryAt`, `maaps`, `mashabetahalich`, `name`, `not`, `open_mashaabim`, `or`, `price`, `project`, `publishedAt`, `quantityDelivered`, `sp`, `spnot`, `sqadualed`, `sqadualef`, `summary`, `total`, `updatedAt`, `users_permissions_user`
 
 #### SaleFiltersInput
-Fields: `and`, `createdAt`, `date`, `finishDate`, `id`, `in`, `isMonterActive`, `matanot`, `monters`, `not`, `note`, `or`, `pending`, `project`, `publishedAt`, `sheiruts`, `splited`, `startDate`, `tosplits`, `unit`, `updatedAt`, `users_permissions_user`
+Fields: `and`, `createdAt`, `date`, `finishDate`, `id`, `in`, `isMonterActive`, `isSiteShareIncome`, `matanot`, `monters`, `not`, `note`, `or`, `pending`, `project`, `publishedAt`, `sheiruts`, `source_project`, `splited`, `startDate`, `tosplits`, `unit`, `updatedAt`, `users_permissions_user`
 
 #### SeederFiltersInput
 Fields: `and`, `createdAt`, `finnish`, `id`, `mesimabetahalich`, `not`, `or`, `publishedAt`, `start`, `updatedAt`
 
 #### SheirutFiltersInput
-Fields: `and`, `archived`, `askwants`, `categories`, `createdAt`, `descrip`, `equaliSplited`, `finnishDate`, `forums`, `halukas`, `iCanGetMonay`, `iGotIt`, `iGotMoney`, `iTransferMoney`, `iTransferedTo`, `id`, `isApruved`, `isItOnlyOneInProject`, `locale`, `localizations`, `matanot`, `moneyTransfered`, `monters`, `name`, `not`, `oneTime`, `or`, `price`, `productExepted`, `project`, `quant`, `sales`, `sheirut_fulfillments`, `sheirutpend`, `source_proposals`, `startDate`, `total`, `updatedAt`, `users_permissions_users`, `wants`, `weFinnish`
+Fields: `and`, `archived`, `askwants`, `categories`, `createdAt`, `descrip`, `equaliSplited`, `finnishDate`, `forums`, `halukas`, `iCanGetMonay`, `iGotIt`, `iGotMoney`, `iTransferMoney`, `iTransferedTo`, `id`, `isApruved`, `isItOnlyOneInProject`, `isSiteShareIncome`, `locale`, `localizations`, `matanot`, `moneyTransfered`, `monters`, `name`, `not`, `oneTime`, `or`, `price`, `productExepted`, `project`, `quant`, `sales`, `sheirut_fulfillments`, `sheirutpend`, `site_share_contributions`, `source_project`, `source_proposals`, `source_tosplit`, `startDate`, `total`, `updatedAt`, `users_permissions_users`, `wants`, `weFinnish`
 
 #### SheirutFulfillmentFiltersInput
 Fields: `agreedPrice`, `and`, `cmdm`, `consumedMissionHours`, `consumedOpenMU`, `createdAt`, `createdMaaps`, `createdMissions`, `createdPmashes`, `id`, `matanot`, `not`, `or`, `process`, `publishedAt`, `quantity`, `sheirut`, `status_process`, `updatedAt`
@@ -5903,6 +6000,9 @@ Fields: `and`, `appruved`, `archived`, `createdAt`, `finnishDate`, `forum`, `id`
 
 #### SidurFiltersInput
 Fields: `and`, `createdAt`, `id`, `lemi`, `not`, `or`, `publishedAt`, `updatedAt`
+
+#### SiteShareContributionFiltersInput
+Fields: `amount`, `and`, `basisAmount`, `createdAt`, `des_status`, `direction`, `haluka`, `id`, `matbea`, `not`, `or`, `project`, `proposedAmount`, `publishedAt`, `reason`, `recive_project`, `sheirut`, `tosplit`, `updatedAt`, `users_permissions_user`
 
 #### SkillFiltersInput
 Fields: `and`, `createdAt`, `descrip`, `id`, `locale`, `localizations`, `missions`, `negopendmissions`, `not`, `open_missions`, `or`, `pendms`, `publishedAt`, `skillName`, `tafkidims`, `updatedAt`, `users`
@@ -5926,7 +6026,7 @@ Fields: `act`, `actt`, `and`, `ask`, `askm`, `askwant`, `createdAt`, `date`, `de
 Fields: `activeMesimabetahalich`, `acts`, `and`, `appruved`, `createdAt`, `finiapruvals`, `finnish`, `forApruve`, `id`, `isActive`, `locale`, `localizations`, `mashabetahalich`, `mesimabetahalich`, `not`, `or`, `project`, `saveLinks`, `saveText`, `saved`, `start`, `timegrama`, `timers`, `totalHours`, `updatedAt`, `users_permissions_user`, `votes`
 
 #### TosplitFiltersInput
-Fields: `and`, `createdAt`, `finished`, `halukas`, `hervachti`, `id`, `locale`, `localizations`, `name`, `not`, `or`, `prectentage`, `project`, `publishedAt`, `ratson_proposal`, `sales`, `split_origin`, `timegrama`, `updatedAt`, `vots`, `whynow`
+Fields: `and`, `createdAt`, `finished`, `halukas`, `hervachti`, `id`, `locale`, `localizations`, `name`, `not`, `or`, `prectentage`, `project`, `publishedAt`, `ratson_proposal`, `sales`, `sheiruts`, `siteShareHalukas`, `site_share_contributions`, `split_origin`, `timegrama`, `updatedAt`, `vots`, `whynow`
 
 #### TranslateFiltersInput
 Fields: `amort`, `amortf`, `amorth`, `amorts`, `amortt`, `and`, `createdAt`, `email`, `from`, `id`, `lang`, `name`, `not`, `notes`, `or`, `publishedAt`, `updatedAt`
@@ -5944,7 +6044,7 @@ Fields: `action`, `and`, `createdAt`, `id`, `not`, `or`, `role`, `updatedAt`
 Fields: `and`, `createdAt`, `description`, `id`, `name`, `not`, `or`, `permissions`, `type`, `updatedAt`, `users`
 
 #### UsersPermissionsUserFiltersInput
-Fields: `acts`, `actsVali`, `and`, `api_keys`, `arr1`, `arrdate`, `askeds`, `askms`, `asks`, `askwants`, `auto_created_via`, `availability_pref`, `bio`, `blocked`, `chezin`, `city`, `confirmationToken`, `confirmed`, `createdAt`, `cuntries`, `cv_extracted_at`, `cv_extraction`, `deals`, `declined`, `declinedByP`, `declinedm`, `device_token`, `discordlink`, `email`, `fblink`, `filtertags`, `finiapruvals`, `finnished_missions`, `forum_last_seens`, `frd`, `free_person`, `githublink`, `haamadas`, `halukasend`, `halukasres`, `haskama`, `haskamac`, `haskamaz`, `hatzaas`, `hervachti`, `iGotMOneyForSheirut`, `id`, `isSigned`, `lang`, `lat`, `levManualAlready`, `lng`, `location`, `machshirs`, `mashaabims`, `mashabetahaliches`, `matanot_recipe_missions`, `matanot_recipe_resources`, `mesimabetahaliches`, `messages`, `missions_i_can_do`, `moachManualAlready`, `nego_mashes`, `negopendmissions`, `negotiations`, `negotiationsIparticipante`, `noMail`, `noOfHoursProject1`, `not`, `onboarding_status`, `onboarding_track`, `open_missions`, `or`, `password`, `pendms`, `pendmsforme`, `pgishas`, `pgishasPendStrat`, `pgishauserpends`, `pgishausers`, `pmashes`, `positionsAuthor`, `positionsVoted`, `preferCards`, `pricing_pref`, `profilManualAlready`, `projects_1s`, `provider`, `radius`, `ratson_proposals`, `ratson_shares`, `ratsons`, `resetPasswordToken`, `rikmashes`, `rishonvesopen`, `role`, `sales`, `sheirutnegos`, `sheirutpends`, `sheiruts`, `sheiruts_iCanGetMonay`, `shekelsPerHoureProject1`, `skills`, `socketId`, `sphmin`, `sps`, `tafkidims`, `telegramId`, `timeForVid`, `timers`, `twiterlink`, `updatedAt`, `username`, `vallues`, `videoval`, `votes`, `wants`, `welcom_tops`, `work_ways`, `zohars`
+Fields: `acts`, `actsVali`, `and`, `api_keys`, `arr1`, `arrdate`, `askeds`, `askms`, `asks`, `askwants`, `auto_created_via`, `availability_pref`, `bio`, `blocked`, `chezin`, `city`, `confirmationToken`, `confirmed`, `createdAt`, `cuntries`, `cv_extracted_at`, `cv_extraction`, `deals`, `declined`, `declinedByP`, `declinedm`, `device_token`, `discordlink`, `email`, `fblink`, `filtertags`, `finiapruvals`, `finnished_missions`, `forum_last_seens`, `frd`, `free_person`, `githublink`, `haamadas`, `halukasend`, `halukasres`, `haskama`, `haskamac`, `haskamaz`, `hatzaas`, `hervachti`, `iGotMOneyForSheirut`, `id`, `isSigned`, `lang`, `lat`, `levManualAlready`, `lng`, `location`, `machshirs`, `mashaabims`, `mashabetahaliches`, `matanot_recipe_missions`, `matanot_recipe_resources`, `mesimabetahaliches`, `messages`, `missions_i_can_do`, `moachManualAlready`, `nego_mashes`, `negopendmissions`, `negotiations`, `negotiationsIparticipante`, `noMail`, `noMoachGuide`, `noOfHoursProject1`, `not`, `onboarding_status`, `onboarding_track`, `open_missions`, `or`, `password`, `pendms`, `pendmsforme`, `pgishas`, `pgishasPendStrat`, `pgishauserpends`, `pgishausers`, `pmashes`, `positionsAuthor`, `positionsVoted`, `preferCards`, `pricing_pref`, `profilManualAlready`, `projects_1s`, `provider`, `radius`, `ratson_proposals`, `ratson_shares`, `ratsons`, `resetPasswordToken`, `rikmashes`, `rishonvesopen`, `role`, `sales`, `sheirutnegos`, `sheirutpends`, `sheiruts`, `sheiruts_iCanGetMonay`, `shekelsPerHoureProject1`, `site_share_contributions`, `skills`, `socketId`, `sphmin`, `sps`, `tafkidims`, `telegramId`, `timeForVid`, `timers`, `twiterlink`, `updatedAt`, `username`, `vallues`, `videoval`, `votes`, `wants`, `welcom_tops`, `work_ways`, `zohars`
 
 #### VallueFiltersInput
 Fields: `and`, `createdAt`, `decisions`, `decisionsles`, `descrip`, `id`, `locale`, `localizations`, `not`, `open_missions`, `or`, `pendms`, `projects`, `publishedAt`, `ratsons`, `updatedAt`, `users`, `valueName`
@@ -5971,12 +6071,12 @@ Fields: `allSubmited`, `and`, `createdAt`, `done`, `id`, `mesimabetahalich`, `no
 
 ---
 
-## 📦 Entity Response Types (367)
+## 📦 Entity Response Types (371)
 
 Wrapper types for GraphQL responses.
 
 <details>
-<summary>Click to expand all 367 response types</summary>
+<summary>Click to expand all 371 response types</summary>
 
 - **ActEntity**: `attributes: Maybe<Act>`, `id: Maybe<Scalars['ID']['output']>`
 - **ActEntityResponse**: `data: Maybe<ActEntity>`
@@ -6263,6 +6363,10 @@ Wrapper types for GraphQL responses.
 - **SidurEntity**: `attributes: Maybe<Sidur>`, `id: Maybe<Scalars['ID']['output']>`
 - **SidurEntityResponse**: `data: Maybe<SidurEntity>`
 - **SidurEntityResponseCollection**: `data: Array<SidurEntity>`, `meta: ResponseCollectionMeta`
+- **SiteShareContributionEntity**: `attributes: Maybe<SiteShareContribution>`, `id: Maybe<Scalars['ID']['output']>`
+- **SiteShareContributionEntityResponse**: `data: Maybe<SiteShareContributionEntity>`
+- **SiteShareContributionEntityResponseCollection**: `data: Array<SiteShareContributionEntity>`, `meta: ResponseCollectionMeta`
+- **SiteShareContributionRelationResponseCollection**: `data: Array<SiteShareContributionEntity>`
 - **SkillEntity**: `attributes: Maybe<Skill>`, `id: Maybe<Scalars['ID']['output']>`
 - **SkillEntityResponse**: `data: Maybe<SkillEntity>`
 - **SkillEntityResponseCollection**: `data: Array<SkillEntity>`, `meta: ResponseCollectionMeta`
@@ -6349,10 +6453,10 @@ Wrapper types for GraphQL responses.
 
 ---
 
-## 🔢 Enum Types (66)
+## 🔢 Enum Types (69)
 
 <details>
-<summary>Click to expand all 66 enum types</summary>
+<summary>Click to expand all 69 enum types</summary>
 
 - **Enum_Act_Hashivut**: 
 - **Enum_Argument_Authortype**: 
@@ -6369,6 +6473,7 @@ Wrapper types for GraphQL responses.
 - **Enum_Contentreleasesreleaseaction_Type**: 
 - **Enum_Decision_Kind**: 
 - **Enum_Forum_Spec**: 
+- **Enum_Haluka_Adjustdirection**: 
 - **Enum_Issue_Origin**: 
 - **Enum_Maap_Unit**: 
 - **Enum_Mashaabim_Kindof**: 
@@ -6411,6 +6516,8 @@ Wrapper types for GraphQL responses.
 - **Enum_Ratson_Willingnessmodel**: 
 - **Enum_Rikmash_Kindof**: 
 - **Enum_Sheirutfulfillment_Status_Process**: 
+- **Enum_Sitesharecontribution_Des_Status**: 
+- **Enum_Sitesharecontribution_Direction**: 
 - **Enum_Sp_Kindof**: 
 - **Enum_Tosplit_Split_Origin**: 
 - **Enum_Userspermissionsuser_Auto_Created_Via**: 
@@ -6435,7 +6542,7 @@ Wrapper types for GraphQL responses.
 ```
 src/
 ├── generated/
-│   ├── graphql.ts              # Auto-generated types (codegen) - 17071 lines
+│   ├── graphql.ts              # Auto-generated types (codegen) - 17356 lines
 │   ├── index.ts                # Re-export hub
 │   └── STRAPI_SCHEMA_REFERENCE.md  # This file (AI agent reference)
 ├── lib/

--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -2718,6 +2718,12 @@ export enum Enum_Forum_Spec {
   Spesificm = 'spesificm'
 }
 
+export enum Enum_Haluka_Adjustdirection {
+  AsIs = 'as_is',
+  Less = 'less',
+  More = 'more'
+}
+
 export enum Enum_Issue_Origin {
   Ai = 'ai',
   Human = 'human'
@@ -3015,6 +3021,18 @@ export enum Enum_Sheirutfulfillment_Status_Process {
   Completed = 'completed',
   Delivered = 'delivered',
   Pending = 'pending'
+}
+
+export enum Enum_Sitesharecontribution_Des_Status {
+  Decided = 'decided',
+  Pending = 'pending',
+  Skipped = 'skipped'
+}
+
+export enum Enum_Sitesharecontribution_Direction {
+  AsIs = 'as_is',
+  Less = 'less',
+  More = 'more'
 }
 
 export enum Enum_Sp_Kindof {
@@ -3658,7 +3676,7 @@ export type ForumRelationResponseCollection = {
   data: Array<ForumEntity>;
 };
 
-export type GenericMorph = Act | Actt | ApiKey | Argument | Ask | Askm | Askwant | Bakasha | Category | Chezin | Clause | ComponentDesisionEditPend | ComponentDesisionNegodes | ComponentDesisionNegom | ComponentNewCoveredMissions | ComponentNewCoveredResources | ComponentNewEdits | ComponentNewExtractedMissions | ComponentNewExtractedResources | ComponentNewLocation | ComponentNewMeeting | ComponentNewMonter | ComponentNewNego | ComponentNewNegom | ComponentNewSeen | ComponentNewTimes | ComponentNewUserAndIshur | ComponentNewWillingnessEntries | ComponentProjectsChatre | ComponentProjectsConsumedMashabetahalichDeliveries | ComponentProjectsConsumedMissionHours | ComponentProjectsConsumedOpenMu | ComponentProjectsDeliveries | ComponentProjectsHervachti | ComponentProjectsIGotMoney | ComponentProjectsMeeting | ComponentProjectsMonter | ComponentProjectsNegodes | ComponentProjectsPendmnego | ComponentProjectsShift | ComponentProjectsTaskdis | ComponentProjectsUsersOf | ComponentProjectsVots | ContentReleasesRelease | ContentReleasesReleaseAction | ConventionText | Cuntry | Dea | Deal | Decision | Deffinition | Filtertag | Finiapruval | FinnishedMission | Forum | ForumLastSeen | Haamada | Haamadapruv | Haluka | Hatzaa | Hazbaah | I18NLocale | Issue | Maap | Machshir | Mashaabim | Mashabetahalich | Matanot | MatanotRecipeMission | MatanotRecipeResource | Matanotpend | Matbea | Mesimabetahalich | Message | Mission | Mode | Monter | Nego | NegoMash | Negopendmission | Negotiation | OpenMashaabim | OpenMission | Partof | Pendm | Pgisha | Pgishauser | Pgishauserpend | Pmash | Position | Project | ProviderProfile | Ratson | RatsonMatchJob | RatsonProposal | RatsonShare | Richtext | Rikmash | Sale | Seeder | Sheirut | SheirutFulfillment | Sheirutnego | Sheirutpend | Sidur | Skill | Solution | Sp | Tafkidim | Tikunolam | Timegrama | Timer | Tosplit | Translate | UploadFile | UploadFolder | UsersPermissionsPermission | UsersPermissionsRole | UsersPermissionsUser | Vallue | Vote | Want | WelcomTop | Whatandwhy | WorkWay | Yat | Zohar;
+export type GenericMorph = Act | Actt | ApiKey | Argument | Ask | Askm | Askwant | Bakasha | Category | Chezin | Clause | ComponentDesisionEditPend | ComponentDesisionNegodes | ComponentDesisionNegom | ComponentNewCoveredMissions | ComponentNewCoveredResources | ComponentNewEdits | ComponentNewExtractedMissions | ComponentNewExtractedResources | ComponentNewLocation | ComponentNewMeeting | ComponentNewMonter | ComponentNewNego | ComponentNewNegom | ComponentNewSeen | ComponentNewTimes | ComponentNewUserAndIshur | ComponentNewWillingnessEntries | ComponentProjectsChatre | ComponentProjectsConsumedMashabetahalichDeliveries | ComponentProjectsConsumedMissionHours | ComponentProjectsConsumedOpenMu | ComponentProjectsDeliveries | ComponentProjectsHervachti | ComponentProjectsIGotMoney | ComponentProjectsMeeting | ComponentProjectsMonter | ComponentProjectsNegodes | ComponentProjectsPendmnego | ComponentProjectsShift | ComponentProjectsTaskdis | ComponentProjectsUsersOf | ComponentProjectsVots | ContentReleasesRelease | ContentReleasesReleaseAction | ConventionText | Cuntry | Dea | Deal | Decision | Deffinition | Filtertag | Finiapruval | FinnishedMission | Forum | ForumLastSeen | Haamada | Haamadapruv | Haluka | Hatzaa | Hazbaah | I18NLocale | Issue | Maap | Machshir | Mashaabim | Mashabetahalich | Matanot | MatanotRecipeMission | MatanotRecipeResource | Matanotpend | Matbea | Mesimabetahalich | Message | Mission | Mode | Monter | Nego | NegoMash | Negopendmission | Negotiation | OpenMashaabim | OpenMission | Partof | Pendm | Pgisha | Pgishauser | Pgishauserpend | Pmash | Position | Project | ProviderProfile | Ratson | RatsonMatchJob | RatsonProposal | RatsonShare | Richtext | Rikmash | Sale | Seeder | Sheirut | SheirutFulfillment | Sheirutnego | Sheirutpend | Sidur | SiteShareContribution | Skill | Solution | Sp | Tafkidim | Tikunolam | Timegrama | Timer | Tosplit | Translate | UploadFile | UploadFolder | UsersPermissionsPermission | UsersPermissionsRole | UsersPermissionsUser | Vallue | Vote | Want | WelcomTop | Whatandwhy | WorkWay | Yat | Zohar;
 
 export type Haamada = {
   __typename?: 'Haamada';
@@ -3810,19 +3828,27 @@ export type HaamadapruvRelationResponseCollection = {
 
 export type Haluka = {
   __typename?: 'Haluka';
+  adjustDirection?: Maybe<Enum_Haluka_Adjustdirection>;
+  adjustReason?: Maybe<Scalars['String']['output']>;
   amount?: Maybe<Scalars['Float']['output']>;
+  autoApproved?: Maybe<Scalars['Boolean']['output']>;
   chatre?: Maybe<Array<Maybe<ComponentProjectsChatre>>>;
   confirmed: Scalars['Boolean']['output'];
   createdAt?: Maybe<Scalars['DateTime']['output']>;
   forum?: Maybe<ForumEntityResponse>;
+  isSiteShare?: Maybe<Scalars['Boolean']['output']>;
   locale?: Maybe<Scalars['String']['output']>;
   localizations?: Maybe<HalukaRelationResponseCollection>;
   matbea?: Maybe<MatbeaEntityResponse>;
   project?: Maybe<ProjectEntityResponse>;
+  proposedAmount?: Maybe<Scalars['Float']['output']>;
   publishedAt?: Maybe<Scalars['DateTime']['output']>;
   ratson_share?: Maybe<RatsonShareEntityResponse>;
+  recive_project?: Maybe<ProjectEntityResponse>;
   senderconf?: Maybe<Scalars['Boolean']['output']>;
   sheirut?: Maybe<SheirutEntityResponse>;
+  site_share_contribution?: Maybe<SiteShareContributionEntityResponse>;
+  source_tosplit?: Maybe<TosplitEntityResponse>;
   tosplit?: Maybe<TosplitEntityResponse>;
   updatedAt?: Maybe<Scalars['DateTime']['output']>;
   userrecive?: Maybe<UsersPermissionsUserEntityResponse>;
@@ -3864,23 +3890,31 @@ export type HalukaEntityResponseCollection = {
 };
 
 export type HalukaFiltersInput = {
+  adjustDirection?: InputMaybe<StringFilterInput>;
+  adjustReason?: InputMaybe<StringFilterInput>;
   amount?: InputMaybe<FloatFilterInput>;
   and?: InputMaybe<Array<InputMaybe<HalukaFiltersInput>>>;
+  autoApproved?: InputMaybe<BooleanFilterInput>;
   chatre?: InputMaybe<ComponentProjectsChatreFiltersInput>;
   confirmed?: InputMaybe<BooleanFilterInput>;
   createdAt?: InputMaybe<DateTimeFilterInput>;
   forum?: InputMaybe<ForumFiltersInput>;
   id?: InputMaybe<IdFilterInput>;
+  isSiteShare?: InputMaybe<BooleanFilterInput>;
   locale?: InputMaybe<StringFilterInput>;
   localizations?: InputMaybe<HalukaFiltersInput>;
   matbea?: InputMaybe<MatbeaFiltersInput>;
   not?: InputMaybe<HalukaFiltersInput>;
   or?: InputMaybe<Array<InputMaybe<HalukaFiltersInput>>>;
   project?: InputMaybe<ProjectFiltersInput>;
+  proposedAmount?: InputMaybe<FloatFilterInput>;
   publishedAt?: InputMaybe<DateTimeFilterInput>;
   ratson_share?: InputMaybe<RatsonShareFiltersInput>;
+  recive_project?: InputMaybe<ProjectFiltersInput>;
   senderconf?: InputMaybe<BooleanFilterInput>;
   sheirut?: InputMaybe<SheirutFiltersInput>;
+  site_share_contribution?: InputMaybe<SiteShareContributionFiltersInput>;
+  source_tosplit?: InputMaybe<TosplitFiltersInput>;
   tosplit?: InputMaybe<TosplitFiltersInput>;
   updatedAt?: InputMaybe<DateTimeFilterInput>;
   userrecive?: InputMaybe<UsersPermissionsUserFiltersInput>;
@@ -3890,16 +3924,24 @@ export type HalukaFiltersInput = {
 };
 
 export type HalukaInput = {
+  adjustDirection?: InputMaybe<Enum_Haluka_Adjustdirection>;
+  adjustReason?: InputMaybe<Scalars['String']['input']>;
   amount?: InputMaybe<Scalars['Float']['input']>;
+  autoApproved?: InputMaybe<Scalars['Boolean']['input']>;
   chatre?: InputMaybe<Array<InputMaybe<ComponentProjectsChatreInput>>>;
   confirmed?: InputMaybe<Scalars['Boolean']['input']>;
   forum?: InputMaybe<Scalars['ID']['input']>;
+  isSiteShare?: InputMaybe<Scalars['Boolean']['input']>;
   matbea?: InputMaybe<Scalars['ID']['input']>;
   project?: InputMaybe<Scalars['ID']['input']>;
+  proposedAmount?: InputMaybe<Scalars['Float']['input']>;
   publishedAt?: InputMaybe<Scalars['DateTime']['input']>;
   ratson_share?: InputMaybe<Scalars['ID']['input']>;
+  recive_project?: InputMaybe<Scalars['ID']['input']>;
   senderconf?: InputMaybe<Scalars['Boolean']['input']>;
   sheirut?: InputMaybe<Scalars['ID']['input']>;
+  site_share_contribution?: InputMaybe<Scalars['ID']['input']>;
+  source_tosplit?: InputMaybe<Scalars['ID']['input']>;
   tosplit?: InputMaybe<Scalars['ID']['input']>;
   userrecive?: InputMaybe<Scalars['ID']['input']>;
   usersend?: InputMaybe<Scalars['ID']['input']>;
@@ -6255,6 +6297,7 @@ export type Mutation = {
   createSheirutpend?: Maybe<SheirutpendEntityResponse>;
   createSheirutpendLocalization?: Maybe<SheirutpendEntityResponse>;
   createSidur?: Maybe<SidurEntityResponse>;
+  createSiteShareContribution?: Maybe<SiteShareContributionEntityResponse>;
   createSkill?: Maybe<SkillEntityResponse>;
   createSkillLocalization?: Maybe<SkillEntityResponse>;
   createSolution?: Maybe<SolutionEntityResponse>;
@@ -6359,6 +6402,7 @@ export type Mutation = {
   deleteSheirutnego?: Maybe<SheirutnegoEntityResponse>;
   deleteSheirutpend?: Maybe<SheirutpendEntityResponse>;
   deleteSidur?: Maybe<SidurEntityResponse>;
+  deleteSiteShareContribution?: Maybe<SiteShareContributionEntityResponse>;
   deleteSkill?: Maybe<SkillEntityResponse>;
   deleteSolution?: Maybe<SolutionEntityResponse>;
   deleteSp?: Maybe<SpEntityResponse>;
@@ -6466,6 +6510,7 @@ export type Mutation = {
   updateSheirutnego?: Maybe<SheirutnegoEntityResponse>;
   updateSheirutpend?: Maybe<SheirutpendEntityResponse>;
   updateSidur?: Maybe<SidurEntityResponse>;
+  updateSiteShareContribution?: Maybe<SiteShareContributionEntityResponse>;
   updateSkill?: Maybe<SkillEntityResponse>;
   updateSolution?: Maybe<SolutionEntityResponse>;
   updateSp?: Maybe<SpEntityResponse>;
@@ -7036,6 +7081,11 @@ export type MutationCreateSidurArgs = {
 };
 
 
+export type MutationCreateSiteShareContributionArgs = {
+  data: SiteShareContributionInput;
+};
+
+
 export type MutationCreateSkillArgs = {
   data: SkillInput;
   locale?: InputMaybe<Scalars['I18NLocaleCode']['input']>;
@@ -7593,6 +7643,11 @@ export type MutationDeleteSheirutpendArgs = {
 
 
 export type MutationDeleteSidurArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+export type MutationDeleteSiteShareContributionArgs = {
   id: Scalars['ID']['input'];
 };
 
@@ -8211,6 +8266,12 @@ export type MutationUpdateSidurArgs = {
 };
 
 
+export type MutationUpdateSiteShareContributionArgs = {
+  data: SiteShareContributionInput;
+  id: Scalars['ID']['input'];
+};
+
+
 export type MutationUpdateSkillArgs = {
   data: SkillInput;
   id: Scalars['ID']['input'];
@@ -8501,6 +8562,7 @@ export type NegoInput = {
 export type NegoMash = {
   __typename?: 'NegoMash';
   createdAt?: Maybe<Scalars['DateTime']['output']>;
+  cycleSize?: Maybe<Scalars['Int']['output']>;
   descrip?: Maybe<Scalars['String']['output']>;
   easy?: Maybe<Scalars['Float']['output']>;
   hm?: Maybe<Scalars['Float']['output']>;
@@ -8512,6 +8574,7 @@ export type NegoMash = {
   pmash?: Maybe<PmashEntityResponse>;
   price?: Maybe<Scalars['Float']['output']>;
   publishedAt?: Maybe<Scalars['DateTime']['output']>;
+  recurring?: Maybe<Scalars['Boolean']['output']>;
   spnot?: Maybe<Scalars['String']['output']>;
   sqadualed?: Maybe<Scalars['DateTime']['output']>;
   sqadualedf?: Maybe<Scalars['DateTime']['output']>;
@@ -8554,6 +8617,7 @@ export type NegoMashEntityResponseCollection = {
 export type NegoMashFiltersInput = {
   and?: InputMaybe<Array<InputMaybe<NegoMashFiltersInput>>>;
   createdAt?: InputMaybe<DateTimeFilterInput>;
+  cycleSize?: InputMaybe<IntFilterInput>;
   descrip?: InputMaybe<StringFilterInput>;
   easy?: InputMaybe<FloatFilterInput>;
   hm?: InputMaybe<FloatFilterInput>;
@@ -8568,6 +8632,7 @@ export type NegoMashFiltersInput = {
   pmash?: InputMaybe<PmashFiltersInput>;
   price?: InputMaybe<FloatFilterInput>;
   publishedAt?: InputMaybe<DateTimeFilterInput>;
+  recurring?: InputMaybe<BooleanFilterInput>;
   spnot?: InputMaybe<StringFilterInput>;
   sqadualed?: InputMaybe<DateTimeFilterInput>;
   sqadualedf?: InputMaybe<DateTimeFilterInput>;
@@ -8577,6 +8642,7 @@ export type NegoMashFiltersInput = {
 };
 
 export type NegoMashInput = {
+  cycleSize?: InputMaybe<Scalars['Int']['input']>;
   descrip?: InputMaybe<Scalars['String']['input']>;
   easy?: InputMaybe<Scalars['Float']['input']>;
   hm?: InputMaybe<Scalars['Float']['input']>;
@@ -8588,6 +8654,7 @@ export type NegoMashInput = {
   pmash?: InputMaybe<Scalars['ID']['input']>;
   price?: InputMaybe<Scalars['Float']['input']>;
   publishedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  recurring?: InputMaybe<Scalars['Boolean']['input']>;
   spnot?: InputMaybe<Scalars['String']['input']>;
   sqadualed?: InputMaybe<Scalars['DateTime']['input']>;
   sqadualedf?: InputMaybe<Scalars['DateTime']['input']>;
@@ -10092,6 +10159,7 @@ export type Pmash = {
   archived: Scalars['Boolean']['output'];
   askm?: Maybe<AskmEntityResponse>;
   createdAt?: Maybe<Scalars['DateTime']['output']>;
+  cycleSize?: Maybe<Scalars['Int']['output']>;
   descrip?: Maybe<Scalars['String']['output']>;
   diun?: Maybe<Array<Maybe<ComponentProjectsVots>>>;
   easy?: Maybe<Scalars['Float']['output']>;
@@ -10115,6 +10183,7 @@ export type Pmash = {
   price?: Maybe<Scalars['Float']['output']>;
   project?: Maybe<ProjectEntityResponse>;
   publishedAt?: Maybe<Scalars['DateTime']['output']>;
+  recurring?: Maybe<Scalars['Boolean']['output']>;
   selfProposalUser?: Maybe<UsersPermissionsUserEntityResponse>;
   sheirut_fulfillments?: Maybe<SheirutFulfillmentRelationResponseCollection>;
   spnot?: Maybe<Scalars['String']['output']>;
@@ -10207,6 +10276,7 @@ export type PmashFiltersInput = {
   archived?: InputMaybe<BooleanFilterInput>;
   askm?: InputMaybe<AskmFiltersInput>;
   createdAt?: InputMaybe<DateTimeFilterInput>;
+  cycleSize?: InputMaybe<IntFilterInput>;
   descrip?: InputMaybe<StringFilterInput>;
   diun?: InputMaybe<ComponentProjectsVotsFiltersInput>;
   easy?: InputMaybe<FloatFilterInput>;
@@ -10233,6 +10303,7 @@ export type PmashFiltersInput = {
   price?: InputMaybe<FloatFilterInput>;
   project?: InputMaybe<ProjectFiltersInput>;
   publishedAt?: InputMaybe<DateTimeFilterInput>;
+  recurring?: InputMaybe<BooleanFilterInput>;
   selfProposalUser?: InputMaybe<UsersPermissionsUserFiltersInput>;
   sheirut_fulfillments?: InputMaybe<SheirutFulfillmentFiltersInput>;
   spnot?: InputMaybe<StringFilterInput>;
@@ -10246,6 +10317,7 @@ export type PmashFiltersInput = {
 export type PmashInput = {
   archived?: InputMaybe<Scalars['Boolean']['input']>;
   askm?: InputMaybe<Scalars['ID']['input']>;
+  cycleSize?: InputMaybe<Scalars['Int']['input']>;
   descrip?: InputMaybe<Scalars['String']['input']>;
   diun?: InputMaybe<Array<InputMaybe<ComponentProjectsVotsInput>>>;
   easy?: InputMaybe<Scalars['Float']['input']>;
@@ -10269,6 +10341,7 @@ export type PmashInput = {
   price?: InputMaybe<Scalars['Float']['input']>;
   project?: InputMaybe<Scalars['ID']['input']>;
   publishedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  recurring?: InputMaybe<Scalars['Boolean']['input']>;
   selfProposalUser?: InputMaybe<Scalars['ID']['input']>;
   sheirut_fulfillments?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   spnot?: InputMaybe<Scalars['String']['input']>;
@@ -10446,6 +10519,7 @@ export type Project = {
   haamadapruvs?: Maybe<HaamadapruvRelationResponseCollection>;
   haamadas?: Maybe<HaamadaRelationResponseCollection>;
   halukas?: Maybe<HalukaRelationResponseCollection>;
+  halukas_recive?: Maybe<HalukaRelationResponseCollection>;
   isMachzikim?: Maybe<Scalars['Boolean']['output']>;
   isMachzikimPublik?: Maybe<Scalars['Boolean']['output']>;
   isOt?: Maybe<Scalars['Boolean']['output']>;
@@ -10478,8 +10552,11 @@ export type Project = {
   restime?: Maybe<Enum_Project_Restime>;
   rikmashes?: Maybe<RikmashRelationResponseCollection>;
   sales?: Maybe<SaleRelationResponseCollection>;
+  sales_source?: Maybe<SaleRelationResponseCollection>;
   sheirutpends?: Maybe<SheirutpendRelationResponseCollection>;
   sheiruts?: Maybe<SheirutRelationResponseCollection>;
+  sheiruts_sourced?: Maybe<SheirutRelationResponseCollection>;
+  site_share_contributions?: Maybe<SiteShareContributionRelationResponseCollection>;
   sps?: Maybe<SpRelationResponseCollection>;
   tafkidims?: Maybe<TafkidimRelationResponseCollection>;
   timeToP?: Maybe<Enum_Project_Timetop>;
@@ -10615,6 +10692,14 @@ export type ProjectHalukasArgs = {
 };
 
 
+export type ProjectHalukas_ReciveArgs = {
+  filters?: InputMaybe<HalukaFiltersInput>;
+  pagination?: InputMaybe<PaginationArg>;
+  publicationState?: InputMaybe<PublicationState>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
 export type ProjectLocalizationsArgs = {
   filters?: InputMaybe<ProjectFiltersInput>;
   pagination?: InputMaybe<PaginationArg>;
@@ -10742,6 +10827,14 @@ export type ProjectSalesArgs = {
 };
 
 
+export type ProjectSales_SourceArgs = {
+  filters?: InputMaybe<SaleFiltersInput>;
+  pagination?: InputMaybe<PaginationArg>;
+  publicationState?: InputMaybe<PublicationState>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
 export type ProjectSheirutpendsArgs = {
   filters?: InputMaybe<SheirutpendFiltersInput>;
   pagination?: InputMaybe<PaginationArg>;
@@ -10752,6 +10845,21 @@ export type ProjectSheirutpendsArgs = {
 export type ProjectSheirutsArgs = {
   filters?: InputMaybe<SheirutFiltersInput>;
   pagination?: InputMaybe<PaginationArg>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type ProjectSheiruts_SourcedArgs = {
+  filters?: InputMaybe<SheirutFiltersInput>;
+  pagination?: InputMaybe<PaginationArg>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type ProjectSite_Share_ContributionsArgs = {
+  filters?: InputMaybe<SiteShareContributionFiltersInput>;
+  pagination?: InputMaybe<PaginationArg>;
+  publicationState?: InputMaybe<PublicationState>;
   sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
 
@@ -10875,6 +10983,7 @@ export type ProjectFiltersInput = {
   haamadapruvs?: InputMaybe<HaamadapruvFiltersInput>;
   haamadas?: InputMaybe<HaamadaFiltersInput>;
   halukas?: InputMaybe<HalukaFiltersInput>;
+  halukas_recive?: InputMaybe<HalukaFiltersInput>;
   id?: InputMaybe<IdFilterInput>;
   isMachzikim?: InputMaybe<BooleanFilterInput>;
   isMachzikimPublik?: InputMaybe<BooleanFilterInput>;
@@ -10908,8 +11017,11 @@ export type ProjectFiltersInput = {
   restime?: InputMaybe<StringFilterInput>;
   rikmashes?: InputMaybe<RikmashFiltersInput>;
   sales?: InputMaybe<SaleFiltersInput>;
+  sales_source?: InputMaybe<SaleFiltersInput>;
   sheirutpends?: InputMaybe<SheirutpendFiltersInput>;
   sheiruts?: InputMaybe<SheirutFiltersInput>;
+  sheiruts_sourced?: InputMaybe<SheirutFiltersInput>;
+  site_share_contributions?: InputMaybe<SiteShareContributionFiltersInput>;
   sps?: InputMaybe<SpFiltersInput>;
   tafkidims?: InputMaybe<TafkidimFiltersInput>;
   timeToP?: InputMaybe<StringFilterInput>;
@@ -10957,6 +11069,7 @@ export type ProjectInput = {
   haamadapruvs?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   haamadas?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   halukas?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
+  halukas_recive?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   isMachzikim?: InputMaybe<Scalars['Boolean']['input']>;
   isMachzikimPublik?: InputMaybe<Scalars['Boolean']['input']>;
   isOt?: InputMaybe<Scalars['Boolean']['input']>;
@@ -10987,8 +11100,11 @@ export type ProjectInput = {
   restime?: InputMaybe<Enum_Project_Restime>;
   rikmashes?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   sales?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
+  sales_source?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   sheirutpends?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   sheiruts?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
+  sheiruts_sourced?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
+  site_share_contributions?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   sps?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   tafkidims?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   timeToP?: InputMaybe<Enum_Project_Timetop>;
@@ -11244,6 +11360,8 @@ export type Query = {
   sheiruts?: Maybe<SheirutEntityResponseCollection>;
   sidur?: Maybe<SidurEntityResponse>;
   sidurs?: Maybe<SidurEntityResponseCollection>;
+  siteShareContribution?: Maybe<SiteShareContributionEntityResponse>;
+  siteShareContributions?: Maybe<SiteShareContributionEntityResponseCollection>;
   skill?: Maybe<SkillEntityResponse>;
   skills?: Maybe<SkillEntityResponseCollection>;
   solution?: Maybe<SolutionEntityResponse>;
@@ -12263,6 +12381,19 @@ export type QuerySidurArgs = {
 
 export type QuerySidursArgs = {
   filters?: InputMaybe<SidurFiltersInput>;
+  pagination?: InputMaybe<PaginationArg>;
+  publicationState?: InputMaybe<PublicationState>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QuerySiteShareContributionArgs = {
+  id?: InputMaybe<Scalars['ID']['input']>;
+};
+
+
+export type QuerySiteShareContributionsArgs = {
+  filters?: InputMaybe<SiteShareContributionFiltersInput>;
   pagination?: InputMaybe<PaginationArg>;
   publicationState?: InputMaybe<PublicationState>;
   sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
@@ -13408,6 +13539,7 @@ export type Sale = {
   finishDate?: Maybe<Scalars['DateTime']['output']>;
   in?: Maybe<Scalars['Float']['output']>;
   isMonterActive?: Maybe<Scalars['Boolean']['output']>;
+  isSiteShareIncome?: Maybe<Scalars['Boolean']['output']>;
   matanot?: Maybe<MatanotEntityResponse>;
   monters?: Maybe<MonterRelationResponseCollection>;
   note?: Maybe<Scalars['String']['output']>;
@@ -13415,6 +13547,7 @@ export type Sale = {
   project?: Maybe<ProjectEntityResponse>;
   publishedAt?: Maybe<Scalars['DateTime']['output']>;
   sheiruts?: Maybe<SheirutRelationResponseCollection>;
+  source_project?: Maybe<ProjectEntityResponse>;
   splited: Scalars['Boolean']['output'];
   startDate?: Maybe<Scalars['DateTime']['output']>;
   tosplits?: Maybe<TosplitRelationResponseCollection>;
@@ -13470,6 +13603,7 @@ export type SaleFiltersInput = {
   id?: InputMaybe<IdFilterInput>;
   in?: InputMaybe<FloatFilterInput>;
   isMonterActive?: InputMaybe<BooleanFilterInput>;
+  isSiteShareIncome?: InputMaybe<BooleanFilterInput>;
   matanot?: InputMaybe<MatanotFiltersInput>;
   monters?: InputMaybe<MonterFiltersInput>;
   not?: InputMaybe<SaleFiltersInput>;
@@ -13479,6 +13613,7 @@ export type SaleFiltersInput = {
   project?: InputMaybe<ProjectFiltersInput>;
   publishedAt?: InputMaybe<DateTimeFilterInput>;
   sheiruts?: InputMaybe<SheirutFiltersInput>;
+  source_project?: InputMaybe<ProjectFiltersInput>;
   splited?: InputMaybe<BooleanFilterInput>;
   startDate?: InputMaybe<DateTimeFilterInput>;
   tosplits?: InputMaybe<TosplitFiltersInput>;
@@ -13492,6 +13627,7 @@ export type SaleInput = {
   finishDate?: InputMaybe<Scalars['DateTime']['input']>;
   in?: InputMaybe<Scalars['Float']['input']>;
   isMonterActive?: InputMaybe<Scalars['Boolean']['input']>;
+  isSiteShareIncome?: InputMaybe<Scalars['Boolean']['input']>;
   matanot?: InputMaybe<Scalars['ID']['input']>;
   monters?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   note?: InputMaybe<Scalars['String']['input']>;
@@ -13499,6 +13635,7 @@ export type SaleInput = {
   project?: InputMaybe<Scalars['ID']['input']>;
   publishedAt?: InputMaybe<Scalars['DateTime']['input']>;
   sheiruts?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
+  source_project?: InputMaybe<Scalars['ID']['input']>;
   splited?: InputMaybe<Scalars['Boolean']['input']>;
   startDate?: InputMaybe<Scalars['DateTime']['input']>;
   tosplits?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
@@ -13581,6 +13718,7 @@ export type Sheirut = {
   iTransferedTo?: Maybe<UsersPermissionsUserRelationResponseCollection>;
   isApruved?: Maybe<Scalars['Boolean']['output']>;
   isItOnlyOneInProject?: Maybe<Scalars['Boolean']['output']>;
+  isSiteShareIncome?: Maybe<Scalars['Boolean']['output']>;
   locale?: Maybe<Scalars['String']['output']>;
   localizations?: Maybe<SheirutRelationResponseCollection>;
   matanot?: Maybe<MatanotEntityResponse>;
@@ -13595,7 +13733,10 @@ export type Sheirut = {
   sales?: Maybe<SaleRelationResponseCollection>;
   sheirut_fulfillments?: Maybe<SheirutFulfillmentRelationResponseCollection>;
   sheirutpend?: Maybe<SheirutpendEntityResponse>;
+  site_share_contributions?: Maybe<SiteShareContributionRelationResponseCollection>;
+  source_project?: Maybe<ProjectEntityResponse>;
   source_proposals?: Maybe<RatsonRelationResponseCollection>;
+  source_tosplit?: Maybe<TosplitEntityResponse>;
   startDate?: Maybe<Scalars['DateTime']['output']>;
   total?: Maybe<Scalars['Float']['output']>;
   updatedAt?: Maybe<Scalars['DateTime']['output']>;
@@ -13687,6 +13828,14 @@ export type SheirutSheirut_FulfillmentsArgs = {
 };
 
 
+export type SheirutSite_Share_ContributionsArgs = {
+  filters?: InputMaybe<SiteShareContributionFiltersInput>;
+  pagination?: InputMaybe<PaginationArg>;
+  publicationState?: InputMaybe<PublicationState>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
 export type SheirutSource_ProposalsArgs = {
   filters?: InputMaybe<RatsonFiltersInput>;
   pagination?: InputMaybe<PaginationArg>;
@@ -13751,6 +13900,7 @@ export type SheirutFiltersInput = {
   id?: InputMaybe<IdFilterInput>;
   isApruved?: InputMaybe<BooleanFilterInput>;
   isItOnlyOneInProject?: InputMaybe<BooleanFilterInput>;
+  isSiteShareIncome?: InputMaybe<BooleanFilterInput>;
   locale?: InputMaybe<StringFilterInput>;
   localizations?: InputMaybe<SheirutFiltersInput>;
   matanot?: InputMaybe<MatanotFiltersInput>;
@@ -13767,7 +13917,10 @@ export type SheirutFiltersInput = {
   sales?: InputMaybe<SaleFiltersInput>;
   sheirut_fulfillments?: InputMaybe<SheirutFulfillmentFiltersInput>;
   sheirutpend?: InputMaybe<SheirutpendFiltersInput>;
+  site_share_contributions?: InputMaybe<SiteShareContributionFiltersInput>;
+  source_project?: InputMaybe<ProjectFiltersInput>;
   source_proposals?: InputMaybe<RatsonFiltersInput>;
+  source_tosplit?: InputMaybe<TosplitFiltersInput>;
   startDate?: InputMaybe<DateTimeFilterInput>;
   total?: InputMaybe<FloatFilterInput>;
   updatedAt?: InputMaybe<DateTimeFilterInput>;
@@ -13892,6 +14045,7 @@ export type SheirutInput = {
   iTransferedTo?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   isApruved?: InputMaybe<Scalars['Boolean']['input']>;
   isItOnlyOneInProject?: InputMaybe<Scalars['Boolean']['input']>;
+  isSiteShareIncome?: InputMaybe<Scalars['Boolean']['input']>;
   matanot?: InputMaybe<Scalars['ID']['input']>;
   moneyTransfered?: InputMaybe<Scalars['Boolean']['input']>;
   monters?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
@@ -13904,7 +14058,10 @@ export type SheirutInput = {
   sales?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   sheirut_fulfillments?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   sheirutpend?: InputMaybe<Scalars['ID']['input']>;
+  site_share_contributions?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
+  source_project?: InputMaybe<Scalars['ID']['input']>;
   source_proposals?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
+  source_tosplit?: InputMaybe<Scalars['ID']['input']>;
   startDate?: InputMaybe<Scalars['DateTime']['input']>;
   total?: InputMaybe<Scalars['Float']['input']>;
   users_permissions_users?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
@@ -14162,6 +14319,88 @@ export type SidurFiltersInput = {
 export type SidurInput = {
   lemi?: InputMaybe<Scalars['String']['input']>;
   publishedAt?: InputMaybe<Scalars['DateTime']['input']>;
+};
+
+export type SiteShareContribution = {
+  __typename?: 'SiteShareContribution';
+  amount?: Maybe<Scalars['Float']['output']>;
+  basisAmount?: Maybe<Scalars['Float']['output']>;
+  createdAt?: Maybe<Scalars['DateTime']['output']>;
+  des_status?: Maybe<Enum_Sitesharecontribution_Des_Status>;
+  direction?: Maybe<Enum_Sitesharecontribution_Direction>;
+  haluka?: Maybe<HalukaEntityResponse>;
+  matbea?: Maybe<MatbeaEntityResponse>;
+  project?: Maybe<ProjectEntityResponse>;
+  proposedAmount?: Maybe<Scalars['Float']['output']>;
+  publishedAt?: Maybe<Scalars['DateTime']['output']>;
+  reason?: Maybe<Scalars['String']['output']>;
+  recive_project?: Maybe<ProjectEntityResponse>;
+  sheirut?: Maybe<SheirutEntityResponse>;
+  tosplit?: Maybe<TosplitEntityResponse>;
+  updatedAt?: Maybe<Scalars['DateTime']['output']>;
+  users_permissions_user?: Maybe<UsersPermissionsUserEntityResponse>;
+};
+
+export type SiteShareContributionEntity = {
+  __typename?: 'SiteShareContributionEntity';
+  attributes?: Maybe<SiteShareContribution>;
+  id?: Maybe<Scalars['ID']['output']>;
+};
+
+export type SiteShareContributionEntityResponse = {
+  __typename?: 'SiteShareContributionEntityResponse';
+  data?: Maybe<SiteShareContributionEntity>;
+};
+
+export type SiteShareContributionEntityResponseCollection = {
+  __typename?: 'SiteShareContributionEntityResponseCollection';
+  data: Array<SiteShareContributionEntity>;
+  meta: ResponseCollectionMeta;
+};
+
+export type SiteShareContributionFiltersInput = {
+  amount?: InputMaybe<FloatFilterInput>;
+  and?: InputMaybe<Array<InputMaybe<SiteShareContributionFiltersInput>>>;
+  basisAmount?: InputMaybe<FloatFilterInput>;
+  createdAt?: InputMaybe<DateTimeFilterInput>;
+  des_status?: InputMaybe<StringFilterInput>;
+  direction?: InputMaybe<StringFilterInput>;
+  haluka?: InputMaybe<HalukaFiltersInput>;
+  id?: InputMaybe<IdFilterInput>;
+  matbea?: InputMaybe<MatbeaFiltersInput>;
+  not?: InputMaybe<SiteShareContributionFiltersInput>;
+  or?: InputMaybe<Array<InputMaybe<SiteShareContributionFiltersInput>>>;
+  project?: InputMaybe<ProjectFiltersInput>;
+  proposedAmount?: InputMaybe<FloatFilterInput>;
+  publishedAt?: InputMaybe<DateTimeFilterInput>;
+  reason?: InputMaybe<StringFilterInput>;
+  recive_project?: InputMaybe<ProjectFiltersInput>;
+  sheirut?: InputMaybe<SheirutFiltersInput>;
+  tosplit?: InputMaybe<TosplitFiltersInput>;
+  updatedAt?: InputMaybe<DateTimeFilterInput>;
+  users_permissions_user?: InputMaybe<UsersPermissionsUserFiltersInput>;
+};
+
+export type SiteShareContributionInput = {
+  amount?: InputMaybe<Scalars['Float']['input']>;
+  basisAmount?: InputMaybe<Scalars['Float']['input']>;
+  des_status?: InputMaybe<Enum_Sitesharecontribution_Des_Status>;
+  direction?: InputMaybe<Enum_Sitesharecontribution_Direction>;
+  haluka?: InputMaybe<Scalars['ID']['input']>;
+  matbea?: InputMaybe<Scalars['ID']['input']>;
+  project?: InputMaybe<Scalars['ID']['input']>;
+  proposedAmount?: InputMaybe<Scalars['Float']['input']>;
+  publishedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  reason?: InputMaybe<Scalars['String']['input']>;
+  recive_project?: InputMaybe<Scalars['ID']['input']>;
+  sheirut?: InputMaybe<Scalars['ID']['input']>;
+  tosplit?: InputMaybe<Scalars['ID']['input']>;
+  users_permissions_user?: InputMaybe<Scalars['ID']['input']>;
+};
+
+export type SiteShareContributionRelationResponseCollection = {
+  __typename?: 'SiteShareContributionRelationResponseCollection';
+  data: Array<SiteShareContributionEntity>;
 };
 
 export type Skill = {
@@ -15028,6 +15267,9 @@ export type Tosplit = {
   publishedAt?: Maybe<Scalars['DateTime']['output']>;
   ratson_proposal?: Maybe<RatsonProposalEntityResponse>;
   sales?: Maybe<SaleRelationResponseCollection>;
+  sheiruts?: Maybe<SheirutRelationResponseCollection>;
+  siteShareHalukas?: Maybe<HalukaRelationResponseCollection>;
+  site_share_contributions?: Maybe<SiteShareContributionRelationResponseCollection>;
   split_origin?: Maybe<Enum_Tosplit_Split_Origin>;
   timegrama?: Maybe<TimegramaEntityResponse>;
   updatedAt?: Maybe<Scalars['DateTime']['output']>;
@@ -15061,6 +15303,29 @@ export type TosplitLocalizationsArgs = {
 
 export type TosplitSalesArgs = {
   filters?: InputMaybe<SaleFiltersInput>;
+  pagination?: InputMaybe<PaginationArg>;
+  publicationState?: InputMaybe<PublicationState>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type TosplitSheirutsArgs = {
+  filters?: InputMaybe<SheirutFiltersInput>;
+  pagination?: InputMaybe<PaginationArg>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type TosplitSiteShareHalukasArgs = {
+  filters?: InputMaybe<HalukaFiltersInput>;
+  pagination?: InputMaybe<PaginationArg>;
+  publicationState?: InputMaybe<PublicationState>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type TosplitSite_Share_ContributionsArgs = {
+  filters?: InputMaybe<SiteShareContributionFiltersInput>;
   pagination?: InputMaybe<PaginationArg>;
   publicationState?: InputMaybe<PublicationState>;
   sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
@@ -15107,6 +15372,9 @@ export type TosplitFiltersInput = {
   publishedAt?: InputMaybe<DateTimeFilterInput>;
   ratson_proposal?: InputMaybe<RatsonProposalFiltersInput>;
   sales?: InputMaybe<SaleFiltersInput>;
+  sheiruts?: InputMaybe<SheirutFiltersInput>;
+  siteShareHalukas?: InputMaybe<HalukaFiltersInput>;
+  site_share_contributions?: InputMaybe<SiteShareContributionFiltersInput>;
   split_origin?: InputMaybe<StringFilterInput>;
   timegrama?: InputMaybe<TimegramaFiltersInput>;
   updatedAt?: InputMaybe<DateTimeFilterInput>;
@@ -15124,6 +15392,9 @@ export type TosplitInput = {
   publishedAt?: InputMaybe<Scalars['DateTime']['input']>;
   ratson_proposal?: InputMaybe<Scalars['ID']['input']>;
   sales?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
+  sheiruts?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
+  siteShareHalukas?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
+  site_share_contributions?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   split_origin?: InputMaybe<Enum_Tosplit_Split_Origin>;
   timegrama?: InputMaybe<Scalars['ID']['input']>;
   vots?: InputMaybe<Array<InputMaybe<ComponentProjectsVotsInput>>>;
@@ -15579,6 +15850,7 @@ export type UsersPermissionsUser = {
   negotiations?: Maybe<NegotiationRelationResponseCollection>;
   negotiationsIparticipante?: Maybe<NegotiationRelationResponseCollection>;
   noMail?: Maybe<Scalars['Boolean']['output']>;
+  noMoachGuide?: Maybe<Scalars['Boolean']['output']>;
   noOfHoursProject1?: Maybe<Scalars['Float']['output']>;
   onboarding_status?: Maybe<Enum_Userspermissionsuser_Onboarding_Status>;
   onboarding_track?: Maybe<Enum_Userspermissionsuser_Onboarding_Track>;
@@ -15611,6 +15883,7 @@ export type UsersPermissionsUser = {
   sheiruts?: Maybe<SheirutRelationResponseCollection>;
   sheiruts_iCanGetMonay?: Maybe<SheirutRelationResponseCollection>;
   shekelsPerHoureProject1?: Maybe<Scalars['Float']['output']>;
+  site_share_contributions?: Maybe<SiteShareContributionRelationResponseCollection>;
   skills?: Maybe<SkillRelationResponseCollection>;
   socketId?: Maybe<Scalars['String']['output']>;
   sphmin?: Maybe<Scalars['Float']['output']>;
@@ -16070,6 +16343,14 @@ export type UsersPermissionsUserSheiruts_ICanGetMonayArgs = {
 };
 
 
+export type UsersPermissionsUserSite_Share_ContributionsArgs = {
+  filters?: InputMaybe<SiteShareContributionFiltersInput>;
+  pagination?: InputMaybe<PaginationArg>;
+  publicationState?: InputMaybe<PublicationState>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
 export type UsersPermissionsUserSkillsArgs = {
   filters?: InputMaybe<SkillFiltersInput>;
   pagination?: InputMaybe<PaginationArg>;
@@ -16231,6 +16512,7 @@ export type UsersPermissionsUserFiltersInput = {
   negotiations?: InputMaybe<NegotiationFiltersInput>;
   negotiationsIparticipante?: InputMaybe<NegotiationFiltersInput>;
   noMail?: InputMaybe<BooleanFilterInput>;
+  noMoachGuide?: InputMaybe<BooleanFilterInput>;
   noOfHoursProject1?: InputMaybe<FloatFilterInput>;
   not?: InputMaybe<UsersPermissionsUserFiltersInput>;
   onboarding_status?: InputMaybe<StringFilterInput>;
@@ -16266,6 +16548,7 @@ export type UsersPermissionsUserFiltersInput = {
   sheiruts?: InputMaybe<SheirutFiltersInput>;
   sheiruts_iCanGetMonay?: InputMaybe<SheirutFiltersInput>;
   shekelsPerHoureProject1?: InputMaybe<FloatFilterInput>;
+  site_share_contributions?: InputMaybe<SiteShareContributionFiltersInput>;
   skills?: InputMaybe<SkillFiltersInput>;
   socketId?: InputMaybe<StringFilterInput>;
   sphmin?: InputMaybe<FloatFilterInput>;
@@ -16352,6 +16635,7 @@ export type UsersPermissionsUserInput = {
   negotiations?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   negotiationsIparticipante?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   noMail?: InputMaybe<Scalars['Boolean']['input']>;
+  noMoachGuide?: InputMaybe<Scalars['Boolean']['input']>;
   noOfHoursProject1?: InputMaybe<Scalars['Float']['input']>;
   onboarding_status?: InputMaybe<Enum_Userspermissionsuser_Onboarding_Status>;
   onboarding_track?: InputMaybe<Enum_Userspermissionsuser_Onboarding_Track>;
@@ -16386,6 +16670,7 @@ export type UsersPermissionsUserInput = {
   sheiruts?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   sheiruts_iCanGetMonay?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   shekelsPerHoureProject1?: InputMaybe<Scalars['Float']['input']>;
+  site_share_contributions?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   skills?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   socketId?: InputMaybe<Scalars['String']['input']>;
   sphmin?: InputMaybe<Scalars['Float']['input']>;

--- a/src/lib/client/actionClient.ts
+++ b/src/lib/client/actionClient.ts
@@ -353,6 +353,7 @@ export interface ActionParamsMap {
     isAssigned?: boolean;
     isReceived?: boolean;
     recurring?: boolean;
+    cycleSize?: number;
     existingSpId?: string;
     restime?: string;
     isOnline?: boolean;

--- a/src/lib/client/actionClient.ts
+++ b/src/lib/client/actionClient.ts
@@ -297,6 +297,7 @@ export type ActionKey =
   | 'addAskmChatEntry'
   | 'addAskChatEntry'
   | 'createWeave'
+  | 'markResourceDone'
   ;
 
 
@@ -351,6 +352,7 @@ export interface ActionParamsMap {
     endDate?: string;
     isAssigned?: boolean;
     isReceived?: boolean;
+    recurring?: boolean;
     existingSpId?: string;
     restime?: string;
     isOnline?: boolean;

--- a/src/lib/components/lev/cards/cards.svelte
+++ b/src/lib/components/lev/cards/cards.svelte
@@ -714,6 +714,9 @@
                       easy={buble.easy}
                       sqadualed={buble.sqadualed}
                       sqadualedf={buble.sqadualedf}
+                      recurring={buble.recurring}
+                      recurringNoEnd={buble.recurringNoEnd}
+                      pricePerUnit={buble.pricePerUnit}
                       linkto={buble.linkto}
                       location={buble.location}
                       pendId={buble.pendId}

--- a/src/lib/components/lev/cards/cards.svelte
+++ b/src/lib/components/lev/cards/cards.svelte
@@ -808,6 +808,13 @@
                       projectName={buble.projectName}
                       useraplyname={buble.username}
                       userId={buble.uid}
+                      myid={buble.myid}
+                      isRecurringCycle={buble.isRecurringCycle}
+                      mashabetahalichId={buble.mashabetahalichId}
+                      cycleIndex={buble.cycleIndex}
+                      quantityDelivered={buble.quantityDelivered}
+                      pricePerUnit={buble.pricePerUnit}
+                      responsibleUserId={buble.responsibleUserId}
                       spid={buble.spid}
                       src={buble.src}
                       price={buble.price}

--- a/src/lib/components/lev/cards/cards.svelte
+++ b/src/lib/components/lev/cards/cards.svelte
@@ -717,6 +717,7 @@
                       recurring={buble.recurring}
                       recurringNoEnd={buble.recurringNoEnd}
                       pricePerUnit={buble.pricePerUnit}
+                      cycleSize={buble.cycleSize}
                       linkto={buble.linkto}
                       location={buble.location}
                       pendId={buble.pendId}

--- a/src/lib/components/lev/cards/pma.svelte
+++ b/src/lib/components/lev/cards/pma.svelte
@@ -71,6 +71,9 @@
     monts,
     yers,
     hm,
+    recurring = false,
+    recurringNoEnd = false,
+    pricePerUnit = 0,
     already = $bindable(),
     allr = false,
     nego_mashes = [],
@@ -271,7 +274,11 @@
   <CardHeader
     logoSrc={src}
     {projectName}
-    cardType={hasUpdatedOffer ? 'הצעה מתוקנת' : 'אישור משאב'}
+    cardType={hasUpdatedOffer
+      ? 'הצעה מתוקנת'
+      : recurring
+        ? '🔁 משאב חוזר · אישרור חודשי'
+        : 'אישור משאב'}
     cardTitle={name}
     memberCount={noofusersOk + noofusersWaiting + noofusersNo}
     {glowColor}
@@ -328,7 +335,24 @@
           alt="howmuch"
         />
 
-        {#if kindOf === 'perUnit'}
+        {#if recurring}
+          <span
+            onmouseenter={() => hover('עלות חודשית משוערת')}
+            onmouseleave={() => hover('0')}
+            class="text-barbi dark:text-pink-400 font-bold"
+          >
+            {(pricePerUnit > 0 ? pricePerUnit : easy > 0 ? easy : price).toLocaleString()}
+            ₪ {kindOf === 'yearly' ? 'לשנה' : 'לחודש'}
+          </span>
+          <span class="text-gray-400">·</span>
+          <span
+            onmouseenter={() => hover('בכל חודש ייפתח חיוב לאישור ההוצאה בפועל')}
+            onmouseleave={() => hover('0')}
+            class="font-black text-gray-900 dark:text-white"
+          >
+            {recurringNoEnd ? '♾️ ללא תאריך סיום' : 'משאב חוזר'}
+          </span>
+        {:else if kindOf === 'perUnit'}
           <span
             onmouseenter={() => hover('שווי ליחידה')}
             onmouseleave={() => hover('0')}

--- a/src/lib/components/lev/cards/pma.svelte
+++ b/src/lib/components/lev/cards/pma.svelte
@@ -91,6 +91,7 @@
     projectId,
     onProj
   } = $props();
+  console.log(recurring, recurringNoEnd, pricePerUnit, '1');
   let user_1s = $derived.by(() => {
     return getProjectData(projectId, 'us') || [];
   });
@@ -341,12 +342,18 @@
             onmouseleave={() => hover('0')}
             class="text-barbi dark:text-pink-400 font-bold"
           >
-            {(pricePerUnit > 0 ? pricePerUnit : easy > 0 ? easy : price).toLocaleString()}
+            {(pricePerUnit > 0
+              ? pricePerUnit
+              : easy > 0
+                ? easy
+                : price
+            ).toLocaleString()}
             ₪ {kindOf === 'yearly' ? 'לשנה' : 'לחודש'}
           </span>
           <span class="text-gray-400">·</span>
           <span
-            onmouseenter={() => hover('בכל חודש ייפתח חיוב לאישור ההוצאה בפועל')}
+            onmouseenter={() =>
+              hover('בכל חודש ייפתח חיוב לאישור ההוצאה בפועל')}
             onmouseleave={() => hover('0')}
             class="font-black text-gray-900 dark:text-white"
           >
@@ -538,7 +545,11 @@
   {#if user_1s && user_1s.length > 0}
     {#if isMobileOrTablet()}
       <div class="pt-2">
-        <VoteStatusDisplay votes={users || []} members={user_1s} {activeOrder} />
+        <VoteStatusDisplay
+          votes={users || []}
+          members={user_1s}
+          {activeOrder}
+        />
       </div>
     {/if}
   {:else}

--- a/src/lib/components/lev/cards/pma.svelte
+++ b/src/lib/components/lev/cards/pma.svelte
@@ -33,6 +33,8 @@
    * @property {any} price
    * @property {any} monts
    * @property {any} yers
+   * @property {any} [sqadualed]
+   * @property {any} [sqadualedf]
    * @property {any} hm
    * @property {boolean} [already]
    * @property {boolean} [allr]
@@ -70,6 +72,8 @@
     price,
     monts,
     yers,
+    sqadualed = null,
+    sqadualedf = null,
     hm,
     recurring = false,
     recurringNoEnd = false,
@@ -218,6 +222,52 @@
   }
 
   const changes = getChanges();
+
+  function isValidDate(d) {
+    if (d == null || d === 'undefined' || d === 'null' || d === '') return false;
+    return !Number.isNaN(new Date(d).getTime());
+  }
+
+  function formatResourceDate(d) {
+    const locale = $lang === 'he' ? 'he-IL' : $lang;
+    return new Date(d).toLocaleDateString(locale);
+  }
+
+  let hasStartDate = $derived(isValidDate(sqadualed));
+  let hasEndDate = $derived(isValidDate(sqadualedf));
+  let hasDateRange = $derived(hasStartDate && hasEndDate);
+  let isYearlyResource = $derived(kindOf === 'yearly');
+  let unitPrice = $derived(
+    pricePerUnit > 0 ? pricePerUnit : easy > 0 ? easy : price
+  );
+
+  let periodCount = $derived.by(() => {
+    if (!hasDateRange) return 0;
+    const start = new Date(sqadualed).getTime();
+    const end = new Date(sqadualedf).getTime();
+    if (end <= start) return 0;
+    const diff = end - start;
+    if (isYearlyResource) {
+      return diff / (1000 * 60 * 60 * 24 * 365.25);
+    }
+    return diff / ((1000 * 60 * 60 * 24 * 365.25) / 12);
+  });
+
+  let dateRangeTotal = $derived.by(() => {
+    if (!hasDateRange || periodCount <= 0) return null;
+    if (recurring || kindOf === 'monthly' || kindOf === 'yearly') {
+      return unitPrice * periodCount;
+    }
+    return null;
+  });
+
+  let showResourcePeriod = $derived(
+    hasStartDate ||
+      hasEndDate ||
+      recurring ||
+      kindOf === 'monthly' ||
+      kindOf === 'yearly'
+  );
 
   function stripHtml(html) {
     if (!html) return '';
@@ -447,6 +497,106 @@
           </span>
         {/if}
       </div>
+
+      {#if showResourcePeriod}
+        <div
+          class="mt-3 pt-3 border-t border-gray-100 dark:border-gray-700 space-y-2"
+        >
+          {#if recurring || kindOf === 'monthly' || kindOf === 'yearly'}
+            <div
+              class="flex items-center gap-2 text-sm font-medium text-gray-600 dark:text-gray-300 flex-wrap"
+            >
+              <span
+                class="px-2 py-0.5 rounded-full bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300"
+              >
+                {isYearlyResource
+                  ? $t('lev.cards.resourcePeriod.yearly')
+                  : $t('lev.cards.resourcePeriod.monthly')}
+              </span>
+              {#if recurring}
+                <span class="text-gray-500 dark:text-gray-400 text-xs"
+                  >🔁 {$t('lev.cards.resourcePeriod.recurring')}</span
+                >
+              {/if}
+            </div>
+          {/if}
+
+          {#if hasStartDate || hasEndDate || (recurring && recurringNoEnd)}
+            <div
+              class="flex items-start gap-2 text-sm text-gray-600 dark:text-gray-300"
+            >
+              <svg
+                class="w-4 h-4 text-blue-500 shrink-0 mt-0.5"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+                ><path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+                ></path></svg
+              >
+              <div class="flex flex-wrap items-center gap-x-2 gap-y-1">
+                {#if hasStartDate}
+                  <span
+                    onmouseenter={() => hover($t('lev.cards.saleCard.startDate'))}
+                    onmouseleave={() => hover('0')}
+                  >
+                    <span class="text-gray-400 dark:text-gray-500"
+                      >{$t('lev.cards.saleCard.startDate')}</span
+                    >
+                    {formatResourceDate(sqadualed)}
+                  </span>
+                {/if}
+                {#if hasEndDate}
+                  {#if hasStartDate}<span class="text-gray-400">–</span>{/if}
+                  <span
+                    onmouseenter={() => hover($t('lev.cards.saleCard.endDate'))}
+                    onmouseleave={() => hover('0')}
+                  >
+                    <span class="text-gray-400 dark:text-gray-500"
+                      >{$t('lev.cards.saleCard.endDate')}</span
+                    >
+                    {formatResourceDate(sqadualedf)}
+                  </span>
+                {:else if recurring && recurringNoEnd}
+                  {#if hasStartDate}<span class="text-gray-400">–</span>{/if}
+                  <span
+                    onmouseenter={() =>
+                      hover($t('lev.cards.resourcePeriod.noEndDate'))}
+                    onmouseleave={() => hover('0')}
+                  >
+                    ♾️ {$t('lev.cards.resourcePeriod.noEndDate')}
+                  </span>
+                {/if}
+              </div>
+            </div>
+          {/if}
+
+          {#if dateRangeTotal != null}
+            <div
+              class="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm font-bold text-gray-900 dark:text-white"
+            >
+              <span
+                class="text-gray-500 dark:text-gray-400 font-medium"
+                onmouseenter={() => hover($t('lev.cards.voteCard.inTotal'))}
+                onmouseleave={() => hover('0')}
+              >
+                {$t('lev.cards.voteCard.inTotal')}:
+              </span>
+              <span>{Math.round(dateRangeTotal).toLocaleString()} ₪</span>
+              <span class="text-gray-400 font-normal text-xs">
+                ({unitPrice.toLocaleString()} × {periodCount.toFixed(1)}
+                {isYearlyResource
+                  ? $t('lev.cards.voteCard.years')
+                  : $t('lev.cards.resourcePeriod.months')})
+              </span>
+            </div>
+          {/if}
+        </div>
+      {/if}
 
       <!-- תיאור והערות -->
       <div class="mt-4 space-y-3">

--- a/src/lib/components/lev/cards/pma.svelte
+++ b/src/lib/components/lev/cards/pma.svelte
@@ -78,6 +78,7 @@
     recurring = false,
     recurringNoEnd = false,
     pricePerUnit = 0,
+    cycleSize = 1,
     already = $bindable(),
     allr = false,
     nego_mashes = [],
@@ -206,7 +207,44 @@
         label: 'מיקום'
       });
     }
+    // Recurring expense toggled (one-time ↔ recurring). recurring is a boolean,
+    // so it can't go through the truthy guards above — compare explicitly, and
+    // only when the snapshot actually carried a recurring value.
+    if (
+      previousOffer.recurring != null &&
+      Boolean(previousOffer.recurring) !== Boolean(recurring)
+    ) {
+      changes.push({
+        type: 'recurring',
+        old: previousOffer.recurring ? 'משאב חוזר' : 'חד פעמי',
+        new: recurring ? 'משאב חוזר' : 'חד פעמי',
+        label: 'סוג חיוב'
+      });
+    }
+    // Billing frequency (every N months/years) changed — only meaningful while
+    // the resource is recurring.
+    if (
+      recurring &&
+      previousOffer.cycleSize &&
+      Number(previousOffer.cycleSize) !== Number(cycleSize)
+    ) {
+      changes.push({
+        type: 'cycleSize',
+        old: cycleLabel(previousOffer.cycleSize),
+        new: cycleLabel(cycleSize),
+        label: 'תדירות'
+      });
+    }
     return changes;
+  }
+
+  // Human label for a billing frequency: "כל חודש" / "כל 3 חודשים" (or years
+  // when the resource is yearly).
+  function cycleLabel(n) {
+    const num = Number(n) || 1;
+    const single = kindOf === 'yearly' ? 'שנה' : 'חודש';
+    const plural = kindOf === 'yearly' ? 'שנים' : 'חודשים';
+    return num === 1 ? `כל ${single}` : `כל ${num} ${plural}`;
   }
 
   function locationSummary(loc) {

--- a/src/lib/components/lev/pmas.svelte
+++ b/src/lib/components/lev/pmas.svelte
@@ -93,6 +93,9 @@
     easy,
     sqadualed,
     sqadualedf,
+    recurring = false,
+    recurringNoEnd = false,
+    pricePerUnit = 0,
     pendId,
     users,
     linkto,
@@ -655,7 +658,29 @@ diunim = ` ${diu},`
           >
             {name}
           </h1>
-          {#if kindOf === 'perUnit'}
+          {#if recurring}
+            <div class="recur" dir="rtl">
+              <p class="p">
+                <span
+                  onmouseenter={() => hover('עלות חודשית משוערת')}
+                  onmouseleave={() => hover('0')}
+                  style="color:var(--gold)">{pricePerUnit > 0 ? pricePerUnit : easy > 0 ? easy : price}</span
+                >
+                <span style="color: aqua">₪ {kindOf === 'yearly' ? 'לשנה' : 'לחודש'}</span>
+              </p>
+              <p class="recur-note">
+                {#if recurringNoEnd}
+                  ♾️ ללא תאריך סיום — עד שיסומן כהושלם
+                {:else}
+                  עד {sqadualedf ? new Date(sqadualedf).toLocaleDateString('he-IL') : ''}
+                {/if}
+              </p>
+              <p class="recur-badge"
+                onmouseenter={() => hover('בכל חודש ייפתח חיוב לאישור ההוצאה בפועל')}
+                onmouseleave={() => hover('0')}
+              >🔁 משאב חוזר · אישרור חודשי</p>
+            </div>
+          {:else if kindOf === 'perUnit'}
             <p class="p">
               <span
                 onmouseenter={() => hover(' שווי ליחידה')}
@@ -944,6 +969,9 @@ diunim = ` ${diu},`
                 {hm}
                 {monts}
                 {yers}
+                {recurring}
+                {recurringNoEnd}
+                {pricePerUnit}
                 {easy}
                 {price}
                 {hearotMeyuchadot}

--- a/src/lib/components/lev/pmas.svelte
+++ b/src/lib/components/lev/pmas.svelte
@@ -225,7 +225,7 @@
       const result = await executeAction('voteOnPmash', {
         pmashId: String(pendId),
         projectId: String(projectId),
-        what: true,
+        what: true
       });
       if (!result.success) {
         await invalidate(() => true); // roll back to server truth
@@ -279,7 +279,7 @@
         pmashId: String(pendId),
         projectId: String(projectId),
         what: false,
-        ...(whyText ? { why: whyText } : {}),
+        ...(whyText ? { why: whyText } : {})
       });
       loading = false;
       if (!result.success) {
@@ -364,7 +364,7 @@
         entityId: String(pendId),
         projectId: String(projectId),
         what: mypos,
-        why,
+        why
       });
       if (result.success) {
         const newDiunId = result.data?.newDiunId;
@@ -664,21 +664,34 @@ diunim = ` ${diu},`
                 <span
                   onmouseenter={() => hover('עלות חודשית משוערת')}
                   onmouseleave={() => hover('0')}
-                  style="color:var(--gold)">{pricePerUnit > 0 ? pricePerUnit : easy > 0 ? easy : price}</span
+                  style="color:var(--gold)"
+                  >{pricePerUnit > 0
+                    ? pricePerUnit
+                    : easy > 0
+                      ? easy
+                      : price}</span
                 >
-                <span style="color: aqua">₪ {kindOf === 'yearly' ? 'לשנה' : 'לחודש'}</span>
+                <span style="color: aqua"
+                  >₪ {kindOf === 'yearly' ? 'לשנה' : 'לחודש'}</span
+                >
               </p>
               <p class="recur-note">
                 {#if recurringNoEnd}
                   ♾️ ללא תאריך סיום — עד שיסומן כהושלם
                 {:else}
-                  עד {sqadualedf ? new Date(sqadualedf).toLocaleDateString('he-IL') : ''}
+                  עד {sqadualedf
+                    ? new Date(sqadualedf).toLocaleDateString('he-IL')
+                    : ''}
                 {/if}
               </p>
-              <p class="recur-badge"
-                onmouseenter={() => hover('בכל חודש ייפתח חיוב לאישור ההוצאה בפועל')}
+              <p
+                class="recur-badge"
+                onmouseenter={() =>
+                  hover('בכל חודש ייפתח חיוב לאישור ההוצאה בפועל')}
                 onmouseleave={() => hover('0')}
-              >🔁 משאב חוזר · אישרור חודשי</p>
+              >
+                🔁 משאב חוזר · אישרור חודשי
+              </p>
             </div>
           {:else if kindOf === 'perUnit'}
             <p class="p">
@@ -1029,6 +1042,9 @@ diunim = ` ${diu},`
     {nego_mashes}
     {timeGramaDate}
     {location}
+    {recurring}
+    {recurringNoEnd}
+    {pricePerUnit}
     {projectId}
     {users}
     activeOrder={order}

--- a/src/lib/components/lev/pmas.svelte
+++ b/src/lib/components/lev/pmas.svelte
@@ -96,6 +96,7 @@
     recurring = false,
     recurringNoEnd = false,
     pricePerUnit = 0,
+    cycleSize = 1,
     pendId,
     users,
     linkto,
@@ -569,6 +570,7 @@ diunim = ` ${diu},`
             {recurring}
             {recurringNoEnd}
             {pricePerUnit}
+            {cycleSize}
             {linkto}
             {pendId}
             {mshaabId}

--- a/src/lib/components/lev/pmas.svelte
+++ b/src/lib/components/lev/pmas.svelte
@@ -990,6 +990,8 @@ diunim = ` ${diu},`
                 {recurring}
                 {recurringNoEnd}
                 {pricePerUnit}
+                {sqadualed}
+                {sqadualedf}
                 {easy}
                 {price}
                 {hearotMeyuchadot}
@@ -1050,6 +1052,8 @@ diunim = ` ${diu},`
     {recurring}
     {recurringNoEnd}
     {pricePerUnit}
+    {sqadualed}
+    {sqadualedf}
     {projectId}
     {users}
     activeOrder={order}

--- a/src/lib/components/lev/pmas.svelte
+++ b/src/lib/components/lev/pmas.svelte
@@ -990,6 +990,7 @@ diunim = ` ${diu},`
                 {recurring}
                 {recurringNoEnd}
                 {pricePerUnit}
+                {cycleSize}
                 {sqadualed}
                 {sqadualedf}
                 {easy}
@@ -1011,7 +1012,7 @@ diunim = ` ${diu},`
                 onNego={claf}
                 {projectId}
                 {users}
-                activeOrder={order}
+                activeOrder={ordern}
                 {onProj}
               />
             </div>
@@ -1052,11 +1053,12 @@ diunim = ` ${diu},`
     {recurring}
     {recurringNoEnd}
     {pricePerUnit}
+    {cycleSize}
     {sqadualed}
     {sqadualedf}
     {projectId}
     {users}
-    activeOrder={order}
+    activeOrder={ordern}
     {onProj}
   />
 {/if}

--- a/src/lib/components/lev/pmas.svelte
+++ b/src/lib/components/lev/pmas.svelte
@@ -566,6 +566,9 @@ diunim = ` ${diu},`
             {noofusers}
             {price}
             {easy}
+            {recurring}
+            {recurringNoEnd}
+            {pricePerUnit}
             {linkto}
             {pendId}
             {mshaabId}

--- a/src/lib/components/lev/weget.svelte
+++ b/src/lib/components/lev/weget.svelte
@@ -102,12 +102,26 @@
     sqadualed,
     sqadualedf,
     cards = false,
+    // Recurring monthly resource cycle (mashabetahalich engine)
+    isRecurringCycle = false,
+    mashabetahalichId,
+    cycleIndex,
+    quantityDelivered = 0,
+    pricePerUnit = 0,
+    responsibleUserId,
+    myid,
     onUser,
     onProj,
     onAcsept,
     onHover,
     onModal
   } = $props();
+
+  // The signed-in user is the one responsible for entering this month's spend.
+  let isResponsible = $derived(
+    isRecurringCycle && String(myid ?? '') === String(responsibleUserId ?? '')
+  );
+  let amountInput = $state(0);
   let resP = [];
   let lang;
   import { Swiper, SwiperSlide } from 'swiper/svelte';
@@ -221,6 +235,15 @@
   });
 
   async function agree() {
+    // Recurring monthly cycle → confirm/edit this month's amount first.
+    if (isRecurringCycle) {
+      amountInput = Number(quantityDelivered || pricePerUnit || 0);
+      spend = true;
+      no = false;
+      masa = false;
+      isOpen = true;
+      return;
+    }
     // Optimistic UI update
     already = true;
     noofusersOk += 1;
@@ -233,6 +256,47 @@
         what: true,
       });
       if (result.success && result.data?.consensus) {
+        onAcsept?.({ ani: 'finim', coinlapach });
+      }
+    } catch (e) {
+      error1 = e;
+      console.log(error1);
+    }
+  }
+
+  // Confirm the monthly spend (counts as a YES vote). The responsible user can
+  // edit the amount; other members simply approve the proposed amount.
+  async function confirmRecurring() {
+    isOpen = false;
+    already = true;
+    noofusersOk += 1;
+    noofusersWaiting -= 1;
+    ser = xyz();
+    try {
+      const result = await executeAction('voteOnMaap', {
+        askId: String(askId),
+        projectId: String(projectId),
+        what: true,
+        ...(isResponsible ? { amount: Number(amountInput) || 0 } : {}),
+      });
+      if (result.success && result.data?.consensus) {
+        onAcsept?.({ ani: 'finim', coinlapach });
+      }
+    } catch (e) {
+      error1 = e;
+      console.log(error1);
+    }
+  }
+
+  // Close the recurring resource entirely (stops future monthly cycles).
+  async function markDone() {
+    isOpen = false;
+    try {
+      const result = await executeAction('markResourceDone', {
+        mashabetahalichId: String(mashabetahalichId),
+        projectId: String(projectId),
+      });
+      if (result.success) {
         onAcsept?.({ ani: 'finim', coinlapach });
       }
     } catch (e) {
@@ -277,10 +341,12 @@
   let whyy = $state(' ');
   let no = $state();
   let masa = $state();
+  let spend = $state(false);
   function close() {
     isOpen = false;
     no = false;
     masa = false;
+    spend = false;
   }
 
   let hovered = $state(false);
@@ -332,7 +398,36 @@
             />
           </svg></button
         >
-        {#if no === true}
+        {#if spend === true}
+          <h1 style="font-size:1.5em;">
+            {isResponsible ? 'כמה הוצאת החודש?' : 'אישור ההוצאה החודשית'}
+          </h1>
+          {#if cycleIndex}
+            <p class="text-barbi" style="font-size:0.9em;">מחזור #{cycleIndex}</p>
+          {/if}
+          {#if isResponsible}
+            <input
+              type="number"
+              min="0"
+              step="0.01"
+              bind:value={amountInput}
+              placeholder="הסכום שהוצא בפועל החודש"
+            />
+          {:else}
+            <p class="p" style="font-size:1.2em; color:var(--gold)">{quantityDelivered} ₪</p>
+          {/if}
+          <br />
+          <button class="add" onclick={confirmRecurring}>אישור ההוצאה</button>
+          {#if mashabetahalichId}
+            <br />
+            <button
+              class="add"
+              style="background-color:var(--barbi-pink); color:var(--gold); margin-top:8px;"
+              onclick={markDone}
+              title="סיום המשאב החודשי — לא ייפתחו עוד חיובים חודשיים"
+            >סיום המשאב (Done)</button>
+          {/if}
+        {:else if no === true}
           <h1 style="font-size:2em;">יש לנמק</h1>
           <input
             minlength="26"
@@ -571,7 +666,18 @@
           >
             {spnot}
           </h2>
-          {#if kindOf === 'perUnit'}
+          {#if isRecurringCycle}
+            <p class="p cd">
+              <span
+                onmouseenter={() => hover('הוצאה חודשית — לחצו על הלב לעדכון ואישור')}
+                onmouseleave={() => hover('0')}
+                style="color:var(--gold)">🔁 {quantityDelivered || pricePerUnit} ₪</span
+              >
+              {#if cycleIndex}
+                <span style="color: aqua; font-size:0.8em;"> · #{cycleIndex}</span>
+              {/if}
+            </p>
+          {:else if kindOf === 'perUnit'}
             <p dir="ltr" class="p cd">
               <span
                 onmouseenter={() => hover(' שווי ליחידה')}

--- a/src/lib/components/mail/monthlyResourceActive.svelte
+++ b/src/lib/components/mail/monthlyResourceActive.svelte
@@ -1,0 +1,148 @@
+<script lang="ts">
+  import {
+    Button,
+    Container,
+    Head,
+    Heading,
+    Hr,
+    Html,
+    Img,
+    Preview,
+    Section,
+    Text
+  } from 'svelty-email';
+
+  /**
+   * Monthly recurring-resource activation email.
+   * Sent by /api/monthi when a new cycle opens, asking the responsible user to
+   * confirm how much was actually spent this month.
+   *
+   * @typedef {Object} Props
+   * @property {string} [username]
+   * @property {string} [resourceName]  - e.g. "שכירות שרת"
+   * @property {string} [projectName]
+   * @property {number} [plannedAmount]
+   * @property {string} [monthLabel]    - e.g. "06/2026"
+   * @property {string} [lang]
+   * @property {string} [previewText]
+   */
+
+  /** @type {Props} */
+  let {
+    username = '',
+    resourceName = '',
+    projectName = '',
+    plannedAmount = 0,
+    monthLabel = '',
+    lang = 'he',
+    previewText = ''
+  } = $props();
+
+  const dir = $derived(lang === 'he' || lang === 'ar' ? 'rtl' : 'ltr');
+
+  const texts = {
+    he: {
+      title: 'משאב חודשי פעיל 🔁',
+      greeting: `שלום ${username},`,
+      intro: `הגיע הזמן לעדכן את ההוצאה החודשית עבור "${resourceName}"${projectName ? ` בריקמה "${projectName}"` : ''} לחודש ${monthLabel}.`,
+      plannedLabel: 'הסכום המתוכנן',
+      ask: 'כנסו לעמוד הלב, אשרו או עדכנו את הסכום שהוצאתם בפועל החודש, וזה יעבור לאישור הריקמה ויירשם בארכיון.',
+      cta: 'עדכון ההוצאה בעמוד הלב',
+      footer: '1💗1 - קשה לבד? קל ביחד!'
+    },
+    en: {
+      title: 'Recurring resource is active 🔁',
+      greeting: `Hello ${username},`,
+      intro: `Time to log this month's expense for "${resourceName}"${projectName ? ` in "${projectName}"` : ''} for ${monthLabel}.`,
+      plannedLabel: 'Planned amount',
+      ask: 'Go to the Lev page, confirm or update what you actually spent this month, and it will go to the weave for approval and be recorded in the archive.',
+      cta: 'Update the expense on Lev',
+      footer: '1💗1 - We can together'
+    },
+    ar: {
+      title: 'المورد المتكرر نشط 🔁',
+      greeting: `مرحبا ${username}،`,
+      intro: `حان وقت تسجيل مصروف هذا الشهر لـ "${resourceName}"${projectName ? ` في "${projectName}"` : ''} لشهر ${monthLabel}.`,
+      plannedLabel: 'المبلغ المخطط',
+      ask: 'ادخل إلى صفحة ليف، أكّد أو حدّث ما أنفقته فعلاً هذا الشهر، وسينتقل للموافقة ويُسجّل في الأرشيف.',
+      cta: 'تحديث المصروف في ليف',
+      footer: '1💗1'
+    }
+  };
+
+  const t = $derived(texts[lang as keyof typeof texts] || texts.he);
+
+  const fontFamily =
+    '-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif';
+  const main = { backgroundColor: '#ffffff', fontFamily };
+  const container = { margin: '0 auto', padding: '20px 0 48px', width: '580px' };
+  const logo = { height: '40px', width: '40px', margin: '0 auto 20px' };
+  const heading = {
+    fontSize: '26px',
+    fontWeight: 'bold',
+    textAlign: 'center' as const,
+    margin: '20px 0',
+    color: '#FF0092'
+  };
+  const greeting = { fontSize: '18px', color: '#333333', marginBottom: '12px' };
+  const intro = { fontSize: '16px', color: '#555555', margin: '0 0 20px' };
+  const amountBox = {
+    background: 'linear-gradient(135deg, #f093fb 0%, #f5576c 100%)',
+    borderRadius: '12px',
+    padding: '24px',
+    textAlign: 'center' as const,
+    margin: '24px 0'
+  };
+  const amountLabel = { fontSize: '14px', color: '#ffffff', margin: '0 0 6px', opacity: '0.9' };
+  const amountText = { fontSize: '40px', fontWeight: 'bold', color: '#ffffff', margin: '0' };
+  const ask = { fontSize: '15px', color: '#666666', margin: '20px 0' };
+  const buttonStyle = {
+    background: 'linear-gradient(135deg, #FF0092 0%, #764ba2 100%)',
+    color: '#ffffff',
+    padding: '15px 40px',
+    borderRadius: '30px',
+    fontSize: '18px',
+    fontWeight: 'bold',
+    textDecoration: 'none'
+  };
+  const hr = { borderColor: '#e9ecef', margin: '40px 0 20px' };
+  const footer = { color: '#999999', fontSize: '14px', textAlign: 'center' as const, margin: '10px 0' };
+</script>
+
+<Html lang={lang}>
+  <Head />
+  <Preview preview={previewText || t.title} />
+  <Section style={main} dir={dir}>
+    <Container style={container}>
+      <Img
+        src="https://res.cloudinary.com/love1/image/upload/v1645647192/apple-touch-icon_irclue.png"
+        width="40"
+        height="40"
+        style={logo}
+        alt="1💗1 Logo"
+      />
+
+      <Heading style={heading}>{t.title}</Heading>
+
+      <Text style={greeting}>{t.greeting}</Text>
+      <Text style={intro}>{t.intro}</Text>
+
+      <Section style={amountBox}>
+        <Text style={amountLabel}>{t.plannedLabel}</Text>
+        <Heading style={amountText}>{plannedAmount} ₪</Heading>
+      </Section>
+
+      <Text style={ask}>{t.ask}</Text>
+
+      <Section style={{ padding: '20px 0', textAlign: 'center' }}>
+        <Button href="https://www.1lev1.com/lev" style={buttonStyle}>{t.cta}</Button>
+      </Section>
+
+      <Hr style={hr} />
+      <Text style={footer}>{t.footer}</Text>
+      <Text style={{ ...footer, fontSize: '12px', marginTop: '10px' }}>
+        <a href="https://www.1lev1.com" style="color: #FF0092; text-decoration: none;">www.1lev1.com</a>
+      </Text>
+    </Container>
+  </Section>
+</Html>

--- a/src/lib/components/prPr/negoPend.svelte
+++ b/src/lib/components/prPr/negoPend.svelte
@@ -89,6 +89,7 @@
     recurring = false,
     recurringNoEnd = false,
     pricePerUnit = 0,
+    cycleSize = 1,
     onClose,
     onLoad
   } = $props();
@@ -104,6 +105,8 @@
   let price2 = $state(price);
   let easy2 = $state(easy);
   let kindOfb = $state(kindOf);
+  let recurring2 = $state(Boolean(recurring));
+  let cycleSize2 = $state(Number(cycleSize) || 1);
   let location2 = $state(
     location
       ? { ...location }
@@ -203,6 +206,16 @@
       originalValues.kindOf = kindOf;
       hasChanges = true;
     }
+    if (Boolean(recurring) !== Boolean(recurring2)) {
+      newValues.recurring = recurring2;
+      originalValues.recurring = recurring;
+      hasChanges = true;
+    }
+    if (recurring2 && Number(cycleSize) !== Number(cycleSize2)) {
+      newValues.cycleSize = Number(cycleSize2) || 1;
+      originalValues.cycleSize = cycleSize;
+      hasChanges = true;
+    }
     if (locationChanged()) {
       newValues.location = {
         location_mode: location2?.location_mode ?? 'unspecified',
@@ -260,7 +273,7 @@
   // yearly) cost, so we never multiply by the number of months — each cycle is
   // approved separately. Fixed-term resources keep multiplying over the period.
   const montsiNew = $derived(
-    recurring ? 1 : Number(montsi(kindOfb, sqadualed2, sqadualedf2)) || 1
+    recurring2 ? 1 : Number(montsi(kindOfb, sqadualed2, sqadualedf2)) || 1
   );
   const montsiOrig = $derived(
     recurring ? 1 : Number(montsi(kindOf, sqadualed, sqadualedf)) || 1
@@ -320,7 +333,7 @@
     {tri?.nego?.headmash[$lang]}
     {name1}
   </h1>
-  {#if recurring}
+  {#if recurring || recurring2}
     <div
       class="mx-2 my-2 rounded-lg border border-gold/60 bg-gold/10 p-2 text-sm text-center"
     >
@@ -366,6 +379,33 @@
       />
     {/if}
 
+    {#if kindOfb === 'monthly' || kindOfb === 'yearly'}
+      <div
+        class="border border-gold border-opacity-40 rounded m-2 p-2 flex flex-col gap-2"
+      >
+        <label class="flex flex-row items-center justify-center gap-x-2">
+          <span class="underline decoration-mturk"
+            >{$lang === 'en' ? 'Recurring expense' : 'הוצאה חוזרת'}</span
+          >
+          <input type="checkbox" bind:checked={recurring2} />
+        </label>
+        {#if recurring2}
+          <p class="text-xs text-center text-barbi/80">
+            {$lang === 'en'
+              ? 'Approved each cycle; leave the end date empty for open-ended.'
+              : 'מאושר בכל מחזור; השאירו תאריך סיום ריק למצב ללא הגבלה.'}
+          </p>
+          <NumberField
+            number={cycleSize}
+            bind:numberb={cycleSize2}
+            lebel={$lang === 'en'
+              ? `Every N ${kindOfb === 'yearly' ? 'years' : 'months'}`
+              : `כל כמה ${kindOfb === 'yearly' ? 'שנים' : 'חודשים'}`}
+          />
+        {/if}
+      </div>
+    {/if}
+
     <LocationNego
       {location}
       bind:locationb={location2}
@@ -394,7 +434,7 @@
     class="border border-gold border-opacity-80 rounded m-2 flex flex-col align-middle justify-center gap-x-2"
   >
     <h2 class="underline decoration-mturk">
-      {#if recurring}
+      {#if recurring2}
         {$lang === 'en' ? 'Estimated cost per cycle' : 'עלות משוערת למחזור'}
       {:else}
         {tri?.mash.tota[$lang]}

--- a/src/lib/components/prPr/negoPend.svelte
+++ b/src/lib/components/prPr/negoPend.svelte
@@ -86,6 +86,9 @@
     ordern = 0,
     masaalr = false,
     location = null,
+    recurring = false,
+    recurringNoEnd = false,
+    pricePerUnit = 0,
     onClose,
     onLoad
   } = $props();
@@ -253,11 +256,14 @@
     kindOf === 'total' ? 1 : Number(hm) || 0
   );
 
+  // For a recurring expense the negotiated price IS the per-cycle (monthly /
+  // yearly) cost, so we never multiply by the number of months — each cycle is
+  // approved separately. Fixed-term resources keep multiplying over the period.
   const montsiNew = $derived(
-    Number(montsi(kindOfb, sqadualed2, sqadualedf2)) || 1
+    recurring ? 1 : Number(montsi(kindOfb, sqadualed2, sqadualedf2)) || 1
   );
   const montsiOrig = $derived(
-    Number(montsi(kindOf, sqadualed, sqadualedf)) || 1
+    recurring ? 1 : Number(montsi(kindOf, sqadualed, sqadualedf)) || 1
   );
 
   const totalNew = $derived(
@@ -314,6 +320,15 @@
     {tri?.nego?.headmash[$lang]}
     {name1}
   </h1>
+  {#if recurring}
+    <div
+      class="mx-2 my-2 rounded-lg border border-gold/60 bg-gold/10 p-2 text-sm text-center"
+    >
+      🔁 {$lang === 'en'
+        ? 'Recurring resource — the value below is the per-cycle (monthly) cost. Every cycle is approved separately. You may leave the end date empty for an open-ended expense.'
+        : 'משאב חוזר — הסכום למטה הוא העלות לכל מחזור (חודשי). כל מחזור עובר אישור בנפרד. ניתן להשאיר תאריך סיום ריק להוצאה ללא הגבלת זמן.'}
+    </div>
+  {/if}
   <div class="flex flex-col align-middle justify-center">
     <Text text={name1} bind:textb={name2} lebel={tri?.common?.name} />
     <Rich
@@ -378,7 +393,13 @@
   <div
     class="border border-gold border-opacity-80 rounded m-2 flex flex-col align-middle justify-center gap-x-2"
   >
-    <h2 class="underline decoration-mturk">{tri?.mash.tota[$lang]}</h2>
+    <h2 class="underline decoration-mturk">
+      {#if recurring}
+        {$lang === 'en' ? 'Estimated cost per cycle' : 'עלות משוערת למחזור'}
+      {:else}
+        {tri?.mash.tota[$lang]}
+      {/if}
+    </h2>
     {#if valuesChanged}
       <div class="flex flex-col gap-2">
         <div>

--- a/src/lib/components/prPr/negoPend.svelte
+++ b/src/lib/components/prPr/negoPend.svelte
@@ -99,7 +99,7 @@
   let sqadualed2 = $state(sqadualed);
   let sqadualedf2 = $state(sqadualedf);
 
-  let spnot2 = spnot;
+  let spnot2 = $state(spnot);
   let linkto2 = $state(linkto);
   let hm2 = $state(hm);
   let price2 = $state(price);
@@ -349,7 +349,11 @@
       bind:textb={descrip2}
       lebel={tri?.common?.description}
     />
-    <!--<Text text={spnot} bind:textb={spnot2} lebel={tri?.mission?.specialNotes}/>-->
+    <Text
+      text={spnot}
+      bind:textb={spnot2}
+      lebel={{ he: 'הערות מיוחדות', en: 'Special notes' }}
+    />
     <Text text={linkto} bind:textb={linkto2} lebel={tri?.mash?.linkto} />
     <KindOfnego {kindOf} bind:kindOfb lebel={tri?.mash.kindof} />
 
@@ -392,8 +396,8 @@
         {#if recurring2}
           <p class="text-xs text-center text-barbi/80">
             {$lang === 'en'
-              ? 'Approved each cycle; leave the end date empty for open-ended.'
-              : 'מאושר בכל מחזור; השאירו תאריך סיום ריק למצב ללא הגבלה.'}
+              ? 'Approved each cycle; clear the end date for an open-ended expense.'
+              : 'מאושר בכל מחזור; ניתן להסיר תאריך סיום למצב ללא הגבלה.'}
           </p>
           <NumberField
             number={cycleSize}
@@ -402,6 +406,16 @@
               ? `Every N ${kindOfb === 'yearly' ? 'years' : 'months'}`
               : `כל כמה ${kindOfb === 'yearly' ? 'שנים' : 'חודשים'}`}
           />
+          <button
+            type="button"
+            onclick={() => (sqadualedf2 = null)}
+            disabled={sqadualedf2 == null || sqadualedf2 === ''}
+            class="mx-auto text-sm border border-gold/50 rounded-full px-3 py-1 hover:bg-gold/20 disabled:opacity-40"
+          >
+            {sqadualedf2 == null || sqadualedf2 === ''
+              ? $lang === 'en' ? '∞ Open-ended (no end date)' : '∞ ללא תאריך סיום'
+              : $lang === 'en' ? 'Remove end date' : 'הסרת תאריך סיום'}
+          </button>
         {/if}
       </div>
     {/if}

--- a/src/lib/components/resource/ResourceCreator.svelte
+++ b/src/lib/components/resource/ResourceCreator.svelte
@@ -60,6 +60,9 @@
   let spnot = $state('');
   let startDate = $state('');
   let endDate = $state('');
+  // Recurring monthly/yearly expense (server rent, apartment, stall…). When on,
+  // the resource becomes a mashabetahalich engine driven by /api/monthi.
+  let isRecurring = $state(false);
 
   let locationOpen = $state(false);
   let locationScope = $state({
@@ -92,13 +95,23 @@
 
   // derived visibility flags
   let showDates = $derived(kindOf === 'monthly' || kindOf === 'yearly');
+  let canBeRecurring = $derived(kindOf === 'monthly' || kindOf === 'yearly');
   let showQuantity = $derived(kindOf === 'perUnit');
   let isSingleUser = $derived(userslength <= 1);
+  // For a recurring expense the end date is optional ("no end date = until done").
   let hasValidDates = $derived(
-    !showDates ||
-      Boolean(startDate && endDate && endDate >= startDate)
+    !showDates
+      ? true
+      : isRecurring
+        ? Boolean(startDate)
+        : Boolean(startDate && endDate && endDate >= startDate)
   );
   let canSubmit = $derived(Boolean(name.trim()) && hasValidDates);
+
+  // Recurring only makes sense for monthly/yearly — clear it otherwise.
+  $effect(() => {
+    if (!canBeRecurring && isRecurring) isRecurring = false;
+  });
 
   // חישוב סה"כ בזמן אמת
   let totalPrice = $derived(
@@ -190,6 +203,9 @@
       success: 'דרישת המשאב פורסמה בהצלחה',
       error: 'שגיאה בפרסום דרישת המשאב',
       datesRequired: 'יש לציין תאריך התחלה ותאריך סיום',
+      recurring: 'הוצאה חוזרת חודשית',
+      recurringHint: 'תשלום קבוע שחוזר כל חודש (שרת, שכירות, דוכן). בכל חודש תתבקשו לאשר את הסכום שהוצא, וזה ייכנס לארכיון לאחר אישור הריקמה.',
+      recurringEndOptional: 'תאריך סיום (לא חובה — עד לסימון כהושלם)',
       totalPrice: 'סה"כ עלות משוערת',
       totalMax: 'סה"כ שווי בריקמה',
       summaryTitle: 'סיכום עלות',
@@ -239,6 +255,9 @@
       success: 'Resource requirement published successfully',
       error: 'Error publishing resource requirement',
       datesRequired: 'Start and end dates are required',
+      recurring: 'Recurring monthly expense',
+      recurringHint: 'A fixed payment that repeats every month (server, rent, stall). Each month you will be asked to confirm the amount spent, and it is archived after the weave approves it.',
+      recurringEndOptional: 'End date (optional — until marked done)',
       totalPrice: 'Total Estimated Cost',
       totalMax: 'Total Maximum Value',
       summaryTitle: 'Cost Summary',
@@ -457,6 +476,7 @@
         price,
         easy: maxInvestment || price,
         kindOf,
+        recurring: isRecurring && (kindOf === 'monthly' || kindOf === 'yearly'),
         hm: showQuantity ? hm : 1,
         linkto,
         spnot,
@@ -606,6 +626,32 @@
           </div>
         {/if}
 
+        {#if canBeRecurring}
+          <div class="md:col-span-2">
+            <button
+              type="button"
+              onclick={() => (isRecurring = !isRecurring)}
+              class="w-full flex items-center justify-between gap-3 rounded-xl border border-gold bg-pink-950/20 p-3 text-start transition-all"
+              class:!bg-gold-600={isRecurring}
+            >
+              <span class="flex flex-col">
+                <span class="text-sm font-semibold text-white">🔁 {t.recurring}</span>
+                <span class="text-xs text-barbie/90">{t.recurringHint}</span>
+              </span>
+              <span
+                class="shrink-0 w-12 h-7 rounded-full flex items-center px-1 transition-colors"
+                class:bg-gold={isRecurring}
+                class:bg-pink-800={!isRecurring}
+              >
+                <span
+                  class="w-5 h-5 rounded-full bg-white transition-transform"
+                  class:translate-x-5={isRecurring}
+                ></span>
+              </span>
+            </button>
+          </div>
+        {/if}
+
         {#if showDates}
           <div class="flex flex-col">
             <label class="text-sm text-barbie mb-1">{t.startDate} *</label>
@@ -619,14 +665,16 @@
             />
           </div>
           <div class="flex flex-col">
-            <label class="text-sm text-barbie mb-1">{t.endDate} *</label>
+            <label class="text-sm text-barbie mb-1"
+              >{isRecurring ? t.recurringEndOptional : `${t.endDate} *`}</label
+            >
             <input
               type="date"
               bind:value={endDate}
               min={startDate || undefined}
-              required
+              required={!isRecurring}
               class="bg-pink-950/30 border border-gold rounded-xl p-3 text-white focus:border-gold outline-none transition-all"
-              class:!border-red-400={showDates && !endDate}
+              class:!border-red-400={showDates && !isRecurring && !endDate}
             />
           </div>
         {/if}

--- a/src/lib/components/resource/ResourceCreator.svelte
+++ b/src/lib/components/resource/ResourceCreator.svelte
@@ -645,7 +645,8 @@
               >
                 <span
                   class="w-5 h-5 rounded-full bg-white transition-transform"
-                  class:translate-x-5={isRecurring}
+                  class:translate-x-5={isRecurring && $lang !== 'he'}
+                  class:-translate-x-5={isRecurring && $lang === 'he'}
                 ></span>
               </span>
             </button>

--- a/src/lib/components/resource/ResourceCreator.svelte
+++ b/src/lib/components/resource/ResourceCreator.svelte
@@ -63,6 +63,9 @@
   // Recurring monthly/yearly expense (server rent, apartment, stall…). When on,
   // the resource becomes a mashabetahalich engine driven by /api/monthi.
   let isRecurring = $state(false);
+  // How often the cycle repeats: every N units (months for monthly, years for
+  // yearly). Defaults to every 1.
+  let cycleSize = $state(1);
 
   let locationOpen = $state(false);
   let locationScope = $state({
@@ -206,6 +209,11 @@
       recurring: 'הוצאה חוזרת חודשית',
       recurringHint: 'תשלום קבוע שחוזר כל חודש (שרת, שכירות, דוכן). בכל חודש תתבקשו לאשר את הסכום שהוצא, וזה ייכנס לארכיון לאחר אישור הריקמה.',
       recurringEndOptional: 'תאריך סיום (לא חובה — עד לסימון כהושלם)',
+      cycleSize: 'תדירות החיוב',
+      cycleSizeHintMonthly: 'כל כמה חודשים נפתח חיוב לאישור (1 = כל חודש)',
+      cycleSizeHintYearly: 'כל כמה שנים נפתח חיוב לאישור (1 = כל שנה)',
+      cycleUnitMonthly: 'חודשים',
+      cycleUnitYearly: 'שנים',
       totalPrice: 'סה"כ עלות משוערת',
       totalMax: 'סה"כ שווי בריקמה',
       summaryTitle: 'סיכום עלות',
@@ -258,6 +266,11 @@
       recurring: 'Recurring monthly expense',
       recurringHint: 'A fixed payment that repeats every month (server, rent, stall). Each month you will be asked to confirm the amount spent, and it is archived after the weave approves it.',
       recurringEndOptional: 'End date (optional — until marked done)',
+      cycleSize: 'Billing frequency',
+      cycleSizeHintMonthly: 'Open a confirmation every N months (1 = every month)',
+      cycleSizeHintYearly: 'Open a confirmation every N years (1 = every year)',
+      cycleUnitMonthly: 'months',
+      cycleUnitYearly: 'years',
       totalPrice: 'Total Estimated Cost',
       totalMax: 'Total Maximum Value',
       summaryTitle: 'Cost Summary',
@@ -477,6 +490,10 @@
         easy: maxInvestment || price,
         kindOf,
         recurring: isRecurring && (kindOf === 'monthly' || kindOf === 'yearly'),
+        cycleSize:
+          isRecurring && (kindOf === 'monthly' || kindOf === 'yearly')
+            ? Math.max(1, Number(cycleSize) || 1)
+            : undefined,
         hm: showQuantity ? hm : 1,
         linkto,
         spnot,
@@ -650,6 +667,32 @@
                 ></span>
               </span>
             </button>
+
+            {#if isRecurring}
+              <div
+                class="mt-3 flex flex-col rounded-xl border border-gold/40 bg-pink-950/10 p-3 animate-in fade-in duration-300"
+              >
+                <label class="text-sm text-barbie mb-1 font-medium"
+                  >{t.cycleSize}</label
+                >
+                <p class="text-xs text-barbie/80 mb-2">
+                  {kindOf === 'yearly'
+                    ? t.cycleSizeHintYearly
+                    : t.cycleSizeHintMonthly}
+                </p>
+                <div class="flex items-center gap-3">
+                  <NumberInput
+                    value={cycleSize}
+                    onValueChange={(v) => (cycleSize = Math.max(1, Number(v) || 1))}
+                  />
+                  <span class="text-sm text-barbie/90 whitespace-nowrap">
+                    {kindOf === 'yearly'
+                      ? t.cycleUnitYearly
+                      : t.cycleUnitMonthly}
+                  </span>
+                </div>
+              </div>
+            {/if}
           </div>
         {/if}
 

--- a/src/lib/server/actions/configs/createResource.ts
+++ b/src/lib/server/actions/configs/createResource.ts
@@ -80,6 +80,34 @@ async function ensureMashaabim(
   return String(createdId);
 }
 
+// ─── recurring-resource helpers ──────────────────────────────────────────
+/** Month/year bounds for the cycle that contains `ref` (default: now). */
+function currentCycleBounds(unit: 'month' | 'year', ref = new Date()) {
+  if (unit === 'year') {
+    const start = new Date(ref.getFullYear(), 0, 1);
+    const end = new Date(ref.getFullYear(), 11, 31, 23, 59, 59);
+    return { cycleStart: start.toISOString(), cycleEnd: end.toISOString() };
+  }
+  const start = new Date(ref.getFullYear(), ref.getMonth(), 1);
+  const end = new Date(ref.getFullYear(), ref.getMonth() + 1, 0, 23, 59, 59);
+  return { cycleStart: start.toISOString(), cycleEnd: end.toISOString() };
+}
+
+async function createMashabetahalichRecord(
+  fetchFn: typeof fetch,
+  jwt: string,
+  data: Record<string, unknown>
+): Promise<string> {
+  const res = await gql(fetchFn, jwt, `
+    mutation MrCreateMashabetahalich($data: MashabetahalichInput!) {
+      createMashabetahalich(data: $data) { data { id } }
+    }
+  `, { data });
+  const id = res?.createMashabetahalich?.data?.id;
+  if (!id) throw new Error('Failed to create Mashabetahalich');
+  return String(id);
+}
+
 // ─── location helper ───────────────────────────────────────────────────────
 function buildLocationInput(
   isOnline?: boolean,
@@ -116,6 +144,7 @@ const createResourceHandler: ActionExecutionHandler = async (params, context) =>
     // Self-assignment params
     isAssigned = false,
     isReceived = false,
+    recurring = false,     // monthly/yearly recurring expense (server rent, apartment…)
     existingSpId,          // ID of an existing Sp record (personal resource)
     restime,               // response-time string used for Timegrama deadline
     isOnline,
@@ -125,8 +154,13 @@ const createResourceHandler: ActionExecutionHandler = async (params, context) =>
     location_hint
   } = params;
 
-  if ((kindOf === 'monthly' || kindOf === 'yearly') && (!startDate || !endDate)) {
-    throw new Error('Start and end dates are required for monthly and yearly resources');
+  if ((kindOf === 'monthly' || kindOf === 'yearly') && !startDate) {
+    throw new Error('Start date is required for monthly and yearly resources');
+  }
+  // Non-recurring monthly/yearly resources are priced over a fixed window and
+  // still need an end date; recurring ones run until the user marks them done.
+  if ((kindOf === 'monthly' || kindOf === 'yearly') && !recurring && !endDate) {
+    throw new Error('End date is required for fixed-term monthly and yearly resources');
   }
 
   const now = new Date().toISOString();
@@ -211,6 +245,111 @@ const createResourceHandler: ActionExecutionHandler = async (params, context) =>
 
   const createdRecord = created[operationName].data;
   const createdId     = createdRecord.id;
+
+  // ── 3b. Recurring expense engine (monthly / yearly) ──────────────────────
+  // A recurring resource is modelled as a "mashabetahalich" with recurring=true.
+  // Each month /api/monthi opens a cycle (a Maap) that surfaces on the lev screen;
+  // the responsible user confirms the amount and it is archived on a Rikmash.
+  const isRecurring =
+    Boolean(recurring) && (kindOf === 'monthly' || kindOf === 'yearly');
+  const cycleUnit: 'month' | 'year' = kindOf === 'yearly' ? 'year' : 'month';
+  const pricePerUnit = (easy && easy > 0 ? easy : price) || 0;
+
+  if (isRecurring && isPmash) {
+    // Multi-member: a DRAFT engine carried on the Pmash. finalizeAskmAcceptance
+    // activates it (status → active + assigns the responsible user) once approved.
+    await createMashabetahalichRecord(f, jwt, {
+      name,
+      descrip: description,
+      project: projectId,
+      mashaabim: ensuredMashaabimId,
+      pmash: createdId,
+      kindOf,
+      unit: cycleUnit,
+      status_mashab: 'draft',
+      recurring: true,
+      start: startDate || now,
+      ...(endDate ? { end: endDate } : {}),
+      cycleSize: 1,
+      pricePerUnit,
+      finnished: false,
+      publishedAt: now
+    });
+  }
+
+  if (isRecurring && !isPmash) {
+    // Single-member: activate immediately, responsible user = creator. Reuse or
+    // create an Sp so the monthly cycle cards carry the provider's identity.
+    let spId = existingSpId ?? null;
+    if (!spId) {
+      const spData = await gql(f, jwt, `
+        mutation CreateSp($data: SpInput!) { createSp(data: $data) { data { id } } }
+      `, {
+        data: {
+          name,
+          descrip: description,
+          kindOf: kindOf || null,
+          unit: hm || null,
+          spnot: spnot || '',
+          price: price || 0,
+          myp: easy || 0,
+          linkto: linkto || '',
+          users_permissions_user: userId,
+          mashaabim: ensuredMashaabimId,
+          publishedAt: now,
+          ...(startDate ? { sdate: startDate } : {}),
+          ...(endDate ? { fdate: endDate } : {}),
+          ...(locationInput ? { location: locationInput } : {})
+        }
+      });
+      spId = spData?.createSp?.data?.id ?? null;
+    }
+
+    const mashabetahalichId = await createMashabetahalichRecord(f, jwt, {
+      name,
+      descrip: description,
+      project: projectId,
+      mashaabim: ensuredMashaabimId,
+      users_permissions_user: userId,
+      kindOf,
+      unit: cycleUnit,
+      status_mashab: 'active',
+      recurring: true,
+      start: startDate || now,
+      ...(endDate ? { end: endDate } : {}),
+      cycleSize: 1,
+      pricePerUnit,
+      finnished: false,
+      publishedAt: now
+    });
+
+    // Open the first cycle (current month) so the card shows on lev right away.
+    const { cycleStart, cycleEnd } = currentCycleBounds(cycleUnit);
+    await gql(f, jwt, `
+      mutation MrCreateCycleMaap($data: MaapInput!) { createMaap(data: $data) { data { id } } }
+    `, {
+      data: {
+        project: projectId,
+        name,
+        mashabetahalich: mashabetahalichId,
+        ...(spId ? { sp: spId } : {}),
+        cycleIndex: 1,
+        cycleStart,
+        cycleEnd,
+        quantityDelivered: pricePerUnit,
+        publishedAt: now
+      }
+    });
+
+    // The OpenMashaabim is vestigial for a recurring resource — the engine + its
+    // monthly cycle Maaps drive the card. Archive it so it doesn't linger as an
+    // open need on the lev screen.
+    await gql(f, jwt, `
+      mutation ArchiveOm($id: ID!) { updateOpenMashaabim(id: $id, data: { archived: true }) { data { id } } }
+    `, { id: createdId });
+
+    return { ...createdRecord, mashabetahalichId, recurring: true };
+  }
 
   // ── 4. Self-assignment follow-up (single-user only) ─────────────────────
   if (isAssigned && !isPmash) {
@@ -512,6 +651,11 @@ export const createResourceAction: ActionConfig = {
       type: 'boolean',
       required: false,
       description: 'Whether the resource has already been received (creates Rikmash instead of Maap)'
+    },
+    recurring: {
+      type: 'boolean',
+      required: false,
+      description: 'Recurring monthly/yearly expense (server rent, apartment, stall). Creates a mashabetahalich engine driven by /api/monthi'
     },
     existingSpId: {
       type: 'string',

--- a/src/lib/server/actions/configs/createResource.ts
+++ b/src/lib/server/actions/configs/createResource.ts
@@ -145,6 +145,7 @@ const createResourceHandler: ActionExecutionHandler = async (params, context) =>
     isAssigned = false,
     isReceived = false,
     recurring = false,     // monthly/yearly recurring expense (server rent, apartment…)
+    cycleSize = 1,         // recurrence period in units of kindOf (e.g. every N months)
     existingSpId,          // ID of an existing Sp record (personal resource)
     restime,               // response-time string used for Timegrama deadline
     isOnline,
@@ -227,6 +228,13 @@ const createResourceHandler: ActionExecutionHandler = async (params, context) =>
       order: 0,
       zman:  now
     }];
+    // Recurring expense flag lives on the Pmash so members can negotiate it.
+    // The mashabetahalich engine itself is created on askm approval from the
+    // final (possibly negotiated) Pmash terms — see runResourceAskmAcceptance.
+    if (recurring && (kindOf === 'monthly' || kindOf === 'yearly')) {
+      resourceData.recurring = true;
+      resourceData.cycleSize = cycleSize ?? 1;
+    }
     if (isAssigned) {
       resourceData.isSelfProposal   = true;
       resourceData.selfProposalUser = userId;
@@ -255,27 +263,8 @@ const createResourceHandler: ActionExecutionHandler = async (params, context) =>
   const cycleUnit: 'month' | 'year' = kindOf === 'yearly' ? 'year' : 'month';
   const pricePerUnit = (easy && easy > 0 ? easy : price) || 0;
 
-  if (isRecurring && isPmash) {
-    // Multi-member: a DRAFT engine carried on the Pmash. finalizeAskmAcceptance
-    // activates it (status → active + assigns the responsible user) once approved.
-    await createMashabetahalichRecord(f, jwt, {
-      name,
-      descrip: description,
-      project: projectId,
-      mashaabim: ensuredMashaabimId,
-      pmash: createdId,
-      kindOf,
-      unit: cycleUnit,
-      status_mashab: 'draft',
-      recurring: true,
-      start: startDate || now,
-      ...(endDate ? { end: endDate } : {}),
-      cycleSize: 1,
-      pricePerUnit,
-      finnished: false,
-      publishedAt: now
-    });
-  }
+  // Multi-member recurring resources carry `recurring`/`cycleSize` on the Pmash
+  // (set above) and the engine is created on approval — nothing more to do here.
 
   if (isRecurring && !isPmash) {
     // Single-member: activate immediately, responsible user = creator. Reuse or
@@ -656,6 +645,11 @@ export const createResourceAction: ActionConfig = {
       type: 'boolean',
       required: false,
       description: 'Recurring monthly/yearly expense (server rent, apartment, stall). Creates a mashabetahalich engine driven by /api/monthi'
+    },
+    cycleSize: {
+      type: 'number',
+      required: false,
+      description: 'Recurrence period in units of kindOf (default 1 = every month/year)'
     },
     existingSpId: {
       type: 'string',

--- a/src/lib/server/actions/configs/finalizeAskmAcceptance.ts
+++ b/src/lib/server/actions/configs/finalizeAskmAcceptance.ts
@@ -3,7 +3,10 @@
  */
 
 import type { ActionConfig, ActionExecutionHandler } from '../types.js';
-import { runResourceAskmAcceptance } from '../helpers/runResourceAskmAcceptance.js';
+import {
+  runResourceAskmAcceptance,
+  activateRecurringEngine,
+} from '../helpers/runResourceAskmAcceptance.js';
 
 const finalizeAskmAcceptanceHandler: ActionExecutionHandler = async (params, context, { strapi }) => {
   const {
@@ -80,7 +83,7 @@ const finalizeAskmAcceptanceHandler: ActionExecutionHandler = async (params, con
     });
   } else {
     // isSelfProposal + pmash — OM/Maap path differs; keep inline until migrated
-    await strapi.execute(
+    const maapRes: any = await strapi.execute(
       '141createMaap',
       {
         data: {
@@ -93,6 +96,14 @@ const finalizeAskmAcceptanceHandler: ActionExecutionHandler = async (params, con
       context.jwt,
       context.fetch
     );
+
+    // Recurring expense? Activate the draft engine and make this Maap cycle #1.
+    await activateRecurringEngine(strapi, context, {
+      projectId: String(projectId),
+      resourceName: String(missionName ?? ''),
+      acceptedUserId: String(acceptedUserId),
+      maapId: maapRes?.data?.createMaap?.data?.id,
+    });
 
     const existingVots = (existingVotes as any[]).map((v: any) => ({
       what: v.what ?? true,

--- a/src/lib/server/actions/configs/index.ts
+++ b/src/lib/server/actions/configs/index.ts
@@ -97,6 +97,7 @@ import { updateUserProfilePicConfig } from './updateUserProfilePic.js';
 import { updateUserBasicConfig } from './updateUserBasic.js';
 import { archiveUserResourceConfig } from './archiveUserResource.js';
 import { createWeaveConfig } from './createWeave.js';
+import { markResourceDoneConfig } from './markResourceDone.js';
 
 
 /**
@@ -266,6 +267,9 @@ export function registerAllActions(): void {
 
   // Weave creation (baci.svelte — "יצירת ריקמה", reusable project creation)
   registerAction(createWeaveConfig);
+
+  // Recurring monthly resources: close a mashabetahalich engine (mark done)
+  registerAction(markResourceDoneConfig);
 
   // Future actions will be registered here
   // registerAction(createTaskAction);

--- a/src/lib/server/actions/configs/markResourceDone.ts
+++ b/src/lib/server/actions/configs/markResourceDone.ts
@@ -1,0 +1,58 @@
+/**
+ * Action Configuration: Mark a recurring resource as done (close the engine)
+ *
+ * A recurring expense (mashabetahalich with recurring=true) keeps opening a new
+ * monthly cycle until its end date passes or the responsible user marks it done.
+ * This action closes the engine: status_mashab → 'closed' and finnished → true,
+ * so /api/monthi stops opening new cycles and the card is archived.
+ */
+
+import type { ActionConfig, ActionExecutionHandler } from '../types.js';
+
+const markResourceDoneHandler: ActionExecutionHandler = async (params, context, { strapi }) => {
+  const { mashabetahalichId } = params;
+
+  await strapi.execute(
+    'mrUpdateMashabetahalich',
+    { id: mashabetahalichId, data: { status_mashab: 'closed', finnished: true } },
+    context.jwt,
+    context.fetch
+  );
+
+  return {
+    data: { mashabetahalichId, closed: true },
+    updateStrategy: { type: 'fullRefresh' },
+  };
+};
+
+export const markResourceDoneConfig: ActionConfig = {
+  key: 'markResourceDone',
+  description: 'Close a recurring resource engine (mashabetahalich): stops monthly cycles and archives it',
+  graphqlOperation: markResourceDoneHandler,
+
+  paramSchema: {
+    mashabetahalichId: { type: 'string', required: true, description: 'ID of the mashabetahalich engine to close' },
+    projectId: { type: 'string', required: true, description: 'Project ID (auth check)' },
+  },
+
+  authRules: [
+    { type: 'jwt' },
+    {
+      type: 'projectMember',
+      config: { projectIdParam: 'projectId' },
+      errorMessage: 'Must be a project member to close a recurring resource',
+    },
+  ],
+
+  notification: {
+    recipients: { type: 'projectMembers', config: { projectIdParam: 'projectId', excludeSender: true } },
+    templates: {
+      title: { he: 'משאב חודשי הסתיים', en: 'Recurring resource closed', ar: 'تم إغلاق المورد المتكرر' },
+      body: { he: 'משאב חודשי סומן כהושלם ונארכב', en: 'A recurring resource was marked done and archived', ar: '' },
+    },
+    channels: ['socket'],
+    metadata: { type: 'resourceDone', url: '/lev?project={{projectId}}' },
+  },
+
+  updateStrategy: { type: 'fullRefresh' },
+};

--- a/src/lib/server/actions/configs/submitNegoMash.ts
+++ b/src/lib/server/actions/configs/submitNegoMash.ts
@@ -48,7 +48,7 @@ const handler: ActionExecutionHandler = async (params, context, { strapi }) => {
     cycleSize: orig.cycleSize ?? null,
     location: (() => {
       const loc = normalizeLocationInput(orig.location);
-      return loc ? [loc] : null;
+      return loc ? [loc] : [];
     })(),
   }, context.jwt, context.fetch);
 

--- a/src/lib/server/actions/configs/submitNegoMash.ts
+++ b/src/lib/server/actions/configs/submitNegoMash.ts
@@ -74,26 +74,25 @@ const handler: ActionExecutionHandler = async (params, context, { strapi }) => {
 
   const allUsers = [...existingUsers, newVote];
 
-  // 4. Build the pmash update data (only changed fields)
-  const nv = params.newValues ?? {};
+  // 4. Build the pmash update data. Apply every field the negotiator actually
+  //    changed — including clears to null/empty (e.g. removing the end date to
+  //    make a recurring expense open-ended). The negotiation form only adds a
+  //    key to newValues when it changed, so key-presence == "changed".
+  const nv: Record<string, any> = params.newValues ?? {};
   const entityData: Record<string, any> = {};
 
-  if (nv.name       != null) entityData.name       = nv.name;
-  if (nv.descrip    != null) entityData.descrip    = nv.descrip;
-  if (nv.spnot      != null) entityData.spnot      = nv.spnot;
-  if (nv.easy       != null) entityData.easy       = nv.easy;
-  if (nv.hm         != null) entityData.hm         = nv.hm;
-  if (nv.price      != null) entityData.price      = nv.price;
-  if (nv.kindOf     != null) entityData.kindOf     = nv.kindOf;
-  if (nv.sqadualed  != null) entityData.sqadualed  = nv.sqadualed;
-  if (nv.sqadualedf != null) entityData.sqadualedf = nv.sqadualedf;
-  if (nv.linkto     != null) entityData.linkto     = nv.linkto;
-  if (nv.recurring  != null) entityData.recurring  = nv.recurring;
-  if (nv.cycleSize  != null) entityData.cycleSize  = nv.cycleSize;
+  const SCALAR_FIELDS = [
+    'name', 'descrip', 'spnot', 'easy', 'hm', 'price', 'kindOf',
+    'sqadualed', 'sqadualedf', 'linkto', 'recurring', 'cycleSize',
+  ];
+  for (const key of SCALAR_FIELDS) {
+    if (key in nv) entityData[key] = nv[key];
+  }
 
-  if (nv.location != null) {
-    const loc = normalizeLocationInput(nv.location);
-    if (loc) entityData.location = loc;
+  if ('location' in nv) {
+    // normalizeLocationInput returns null for an empty location → applying null
+    // clears the component, so the location can be removed in a negotiation too.
+    entityData.location = normalizeLocationInput(nv.location);
   }
 
   entityData.users = allUsers;
@@ -109,19 +108,13 @@ const handler: ActionExecutionHandler = async (params, context, { strapi }) => {
   // refresh that would reset the user's scroll/swiper position. The card face
   // (name, totals, vote counts) updates immediately.
   const patch: Record<string, any> = {};
-  if (nv.name       != null) patch.name       = nv.name;
-  if (nv.descrip    != null) patch.descrip    = nv.descrip;
-  if (nv.spnot      != null) patch.spnot      = nv.spnot;
-  if (nv.easy       != null) patch.easy       = nv.easy;
-  if (nv.hm         != null) patch.hm         = nv.hm;
-  if (nv.price      != null) patch.price      = nv.price;
-  if (nv.kindOf     != null) patch.resourceType = nv.kindOf;
-  if (nv.sqadualed  != null) patch.sqadualed  = nv.sqadualed;
-  if (nv.sqadualedf != null) patch.sqadualedf = nv.sqadualedf;
-  if (nv.linkto     != null) patch.linkto     = nv.linkto;
-  if (nv.recurring  != null) patch.recurring  = nv.recurring;
-  if (nv.cycleSize  != null) patch.cycleSize  = nv.cycleSize;
-  if (entityData.location != null) patch.location = entityData.location;
+  for (const key of SCALAR_FIELDS) {
+    if (!(key in nv)) continue;
+    // The pmashes store keys resource kind as `resourceType`.
+    if (key === 'kindOf') patch.resourceType = nv.kindOf;
+    else patch[key] = nv[key];
+  }
+  if ('location' in nv) patch.location = entityData.location;
 
   // Negotiator's vote in the Strapi-nested shape processPmashes/mergeVote expect.
   const strapiVote: Record<string, any> = {

--- a/src/lib/server/actions/configs/submitNegoMash.ts
+++ b/src/lib/server/actions/configs/submitNegoMash.ts
@@ -44,6 +44,8 @@ const handler: ActionExecutionHandler = async (params, context, { strapi }) => {
     sqadualed: orig.sqadualed ?? null,
     sqadualedf: orig.sqadualedf ?? null,
     linkto: orig.linkto ?? null,
+    recurring: orig.recurring ?? null,
+    cycleSize: orig.cycleSize ?? null,
     location: (() => {
       const loc = normalizeLocationInput(orig.location);
       return loc ? [loc] : null;
@@ -86,6 +88,8 @@ const handler: ActionExecutionHandler = async (params, context, { strapi }) => {
   if (nv.sqadualed  != null) entityData.sqadualed  = nv.sqadualed;
   if (nv.sqadualedf != null) entityData.sqadualedf = nv.sqadualedf;
   if (nv.linkto     != null) entityData.linkto     = nv.linkto;
+  if (nv.recurring  != null) entityData.recurring  = nv.recurring;
+  if (nv.cycleSize  != null) entityData.cycleSize  = nv.cycleSize;
 
   if (nv.location != null) {
     const loc = normalizeLocationInput(nv.location);
@@ -115,6 +119,8 @@ const handler: ActionExecutionHandler = async (params, context, { strapi }) => {
   if (nv.sqadualed  != null) patch.sqadualed  = nv.sqadualed;
   if (nv.sqadualedf != null) patch.sqadualedf = nv.sqadualedf;
   if (nv.linkto     != null) patch.linkto     = nv.linkto;
+  if (nv.recurring  != null) patch.recurring  = nv.recurring;
+  if (nv.cycleSize  != null) patch.cycleSize  = nv.cycleSize;
   if (entityData.location != null) patch.location = entityData.location;
 
   // Negotiator's vote in the Strapi-nested shape processPmashes/mergeVote expect.
@@ -144,7 +150,7 @@ export const submitNegoMashConfig: ActionConfig = {
     restime:        { type: 'string',  required: false, description: 'Project restime: feh|sth|nsh|sevend' },
     isOriginal:     { type: 'boolean', required: false, description: 'True if this is the first negotiation (stepState === 2)' },
     ordern:         { type: 'number',  required: false, description: 'Current order index (new vote gets ordern+1)' },
-    newValues:      { type: 'object',  required: false, description: 'Changed field values to apply (name, descrip, spnot, easy, hm, price, kindOf, sqadualed, sqadualedf, linkto, location)' },
+    newValues:      { type: 'object',  required: false, description: 'Changed field values to apply (name, descrip, spnot, easy, hm, price, kindOf, sqadualed, sqadualedf, linkto, location, recurring, cycleSize)' },
     originalValues: { type: 'object',  required: false, description: 'Original values before the change (for the snapshot)' },
     users:          { type: 'array',   required: false, description: 'Existing users/votes array on the pmash' },
   },

--- a/src/lib/server/actions/configs/voteOnMaap.ts
+++ b/src/lib/server/actions/configs/voteOnMaap.ts
@@ -50,8 +50,145 @@ function computeTotal(kindOf: string, agprice: number, hm: number, sqadualed?: s
   return agprice;
 }
 
+/**
+ * Vote on a recurring monthly cycle Maap.
+ *
+ * Each month /api/monthi opens a cycle Maap (linked to a mashabetahalich engine)
+ * pre-filled with the planned amount. The responsible user confirms / edits the
+ * real amount (passed as `amount`), which counts as their YES vote. On full
+ * project consensus the spend is appended as a delivery line on the engine's
+ * Rikmash (created on the first cycle) and the cycle Maap is archived.
+ */
+async function handleCycleMaapVote(
+  strapi: any,
+  context: any,
+  args: {
+    askId: string;
+    projectId: string;
+    what: boolean;
+    why?: string;
+    amount?: number;
+    attrs: any;
+    mashab: any;
+    now: Date;
+  },
+) {
+  const { askId, projectId, what, why, amount, attrs, mashab, now } = args;
+  const mashId = String(mashab.id);
+  const mashAttrs = mashab.attributes ?? {};
+  const responsibleId = String(mashAttrs.users_permissions_user?.data?.id ?? '');
+  const kindOf = mashAttrs.kindOf ?? 'monthly';
+  const hasAmount = amount != null && !Number.isNaN(amount);
+
+  // Resolve the spend amount: explicit > already-stored > planned price.
+  const spend: number = hasAmount
+    ? (amount as number)
+    : attrs.quantityDelivered ?? mashAttrs.pricePerUnit ?? 0;
+
+  // Members & quorum
+  const projectRes = await strapi.execute('3projectJSONQue', { pid: projectId }, context.jwt, context.fetch);
+  const members = projectRes?.data?.project?.data?.attributes?.user_1s?.data ?? [];
+  const memberIds: string[] = members.map((m: any) => String(m.id));
+  const totalMembers = memberIds.length;
+
+  // Build vots (dedup current user)
+  const existingVots: any[] = attrs.vots ?? [];
+  const strUserId = String(context.userId);
+  const previousVotes = existingVots
+    .filter((v: any) => {
+      const uid = v.users_permissions_user?.data?.id ?? v.users_permissions_user;
+      return String(uid) !== strUserId;
+    })
+    .map(normalizeVote);
+  const newVote: Record<string, any> = { what: Boolean(what), users_permissions_user: strUserId };
+  if (why) newVote.why = why;
+  const allVots = [...previousVotes, newVote];
+
+  const yesCount = allVots.filter(
+    (v) => v.what === true && memberIds.includes(String(v.users_permissions_user)),
+  ).length;
+  const consensus = what === true && totalMembers > 0 && yesCount >= totalMembers;
+
+  if (!consensus) {
+    const data: Record<string, any> = { vots: allVots };
+    if (hasAmount) data.quantityDelivered = spend;
+    await strapi.execute('mrUpdateCycleMaap', { id: askId, data }, context.jwt, context.fetch);
+    return {
+      data: { askId, consensus: false },
+      updateStrategy: { type: 'partialUpdate', config: { dataKeys: ['wegets'] } },
+    };
+  }
+
+  // ── Consensus: archive the month's spend as a delivery on the Rikmash ──────
+  const cycleIndex = attrs.cycleIndex ?? 1;
+  let rikmashId: string | null = mashAttrs.rikmash?.data?.id ?? null;
+
+  if (rikmashId) {
+    const rRes = await strapi.execute('mrGetRikmashForDelivery', { id: rikmashId }, context.jwt, context.fetch);
+    const rAttrs = rRes?.data?.rikmash?.data?.attributes ?? {};
+    const existingDeliveries = (rAttrs.deliveries ?? []).map((d: any) => ({
+      id: d.id,
+      cycleIndex: d.cycleIndex,
+      deliveredAt: d.deliveredAt,
+      quantity: d.quantity,
+      ...(d.note ? { note: d.note } : {}),
+      ...(d.maap?.data?.id ? { maap: d.maap.data.id } : {}),
+    }));
+    const deliveries = [
+      ...existingDeliveries,
+      { cycleIndex, deliveredAt: now.toISOString(), quantity: spend, maap: askId, confirmedBy: strUserId },
+    ];
+    await strapi.execute('mrUpdateRikmash', {
+      id: rikmashId,
+      data: {
+        deliveries,
+        total: (rAttrs.total ?? 0) + spend,
+        cyclesCount: (rAttrs.cyclesCount ?? 0) + 1,
+        lastDeliveryAt: now.toISOString(),
+      },
+    }, context.jwt, context.fetch);
+  } else {
+    const created = await strapi.execute('mrCreateRikmash', {
+      data: {
+        name: mashAttrs.name ?? attrs.name ?? 'משאב',
+        project: projectId,
+        mashabetahalich: mashId,
+        kindOf,
+        ...(responsibleId ? { users_permissions_user: responsibleId } : {}),
+        total: spend,
+        agprice: mashAttrs.pricePerUnit ?? spend,
+        cyclesCount: 1,
+        firstDeliveryAt: now.toISOString(),
+        lastDeliveryAt: now.toISOString(),
+        deliveries: [
+          { cycleIndex, deliveredAt: now.toISOString(), quantity: spend, maap: askId, confirmedBy: strUserId },
+        ],
+        maaps: [askId],
+        publishedAt: now.toISOString(),
+      },
+    }, context.jwt, context.fetch);
+    rikmashId = created?.data?.createRikmash?.data?.id ?? null;
+    if (rikmashId) {
+      await strapi.execute('mrLinkRikmashToMashabetahalich', { id: mashId, rikmash: rikmashId }, context.jwt, context.fetch);
+    }
+  }
+
+  // Archive the cycle Maap + accumulate the engine's running total.
+  await strapi.execute('mrUpdateCycleMaap', {
+    id: askId,
+    data: { archived: true, vots: allVots, quantityDelivered: spend, ...(rikmashId ? { rikmash: rikmashId } : {}) },
+  }, context.jwt, context.fetch);
+
+  await strapi.execute('mrUpdateMashabetahalich', {
+    id: mashId,
+    data: { quantityDelivered: (mashAttrs.quantityDelivered ?? 0) + spend },
+  }, context.jwt, context.fetch);
+
+  return { data: { askId, rikmashId, consensus: true }, updateStrategy: { type: 'fullRefresh' } };
+}
+
 const voteOnMaapHandler: ActionExecutionHandler = async (params, context, { strapi }) => {
-  const { askId, projectId, what, why } = params;
+  const { askId, projectId, what, why, amount } = params;
 
   const now = new Date();
 
@@ -60,6 +197,22 @@ const voteOnMaapHandler: ActionExecutionHandler = async (params, context, { stra
   const maapData = maapRes?.data?.maap?.data;
   if (!maapData) throw new Error(`Maap ${askId} not found`);
   const attrs = maapData.attributes;
+
+  // ── Recurring cycle Maap: a monthly spend awaiting confirmation. Archive the
+  //    confirmed amount as a delivery line on the engine's Rikmash. ──────────
+  const mashab = attrs.mashabetahalich?.data;
+  if (mashab) {
+    return handleCycleMaapVote(strapi, context, {
+      askId: String(askId),
+      projectId: String(projectId),
+      what: Boolean(what),
+      why,
+      amount: amount != null ? Number(amount) : undefined,
+      attrs,
+      mashab,
+      now,
+    });
+  }
 
   const sp = attrs.sp?.data;
   const om = attrs.open_mashaabim?.data;
@@ -236,6 +389,7 @@ export const voteOnMaapConfig: ActionConfig = {
     projectId: { type: 'string', required: true, description: 'Project ID' },
     what: { type: 'boolean', required: true, description: 'true = agree, false = decline' },
     why: { type: 'string', required: false, description: 'Optional decline reason' },
+    amount: { type: 'number', required: false, description: 'For recurring cycle Maaps: the confirmed amount spent this month' },
   },
 
   authRules: [

--- a/src/lib/server/actions/helpers/runResourceAskmAcceptance.ts
+++ b/src/lib/server/actions/helpers/runResourceAskmAcceptance.ts
@@ -57,11 +57,12 @@ function currentCycleBounds(unit: 'month' | 'year', ref = new Date()) {
 }
 
 /**
- * If a DRAFT recurring engine was created for this resource at proposal time
- * (createResource, multi-member branch), activate it on approval: status →
- * active, assign the responsible user, and turn the freshly-created acceptance
- * Maap into cycle #1 (links it to the engine + sets the cycle window/amount).
- * No-op for non-recurring resources.
+ * When the approved resource is a recurring expense (the final, possibly
+ * negotiated, Pmash is still flagged recurring), spin up the mashabetahalich
+ * engine on approval: create it active, assign the responsible user, configure
+ * it from the Pmash's final terms, and turn the freshly-created acceptance Maap
+ * into cycle #1. No-op for non-recurring resources (incl. those negotiated from
+ * recurring → false, since the query filters recurring: true).
  */
 export async function activateRecurringEngine(
   strapi: StrapiExecutor,
@@ -72,65 +73,68 @@ export async function activateRecurringEngine(
   if (!resourceName) return;
 
   const res: any = await strapi.execute(
-    'mrGetDraftMashForProject',
+    'mrGetPmashRecurringTerms',
     { pid: projectId, name: resourceName },
     context.jwt,
     context.fetch
   );
-  const draft = res?.data?.mashabetahaliches?.data?.[0];
-  if (!draft) return;
+  const pmash = res?.data?.pmashes?.data?.[0];
+  if (!pmash) return; // not recurring (or negotiated off) → nothing to do
 
-  const attrs = draft.attributes ?? {};
-  // Prefer the final negotiated terms carried on the linked Pmash (members may
-  // have negotiated the monthly cost / period before approval) over the draft's
-  // initial values.
-  const pm = attrs.pmash?.data?.attributes ?? {};
-  const kindOfFinal = pm.kindOf ?? attrs.kindOf;
-  const unit: 'month' | 'year' = kindOfFinal === 'yearly' ? 'year' : 'month';
+  const pm = pmash.attributes ?? {};
+  const kindOf = pm.kindOf === 'yearly' ? 'yearly' : 'monthly';
+  const unit: 'month' | 'year' = kindOf === 'yearly' ? 'year' : 'month';
   const negEasy = Number(pm.easy) || 0;
   const negPrice = Number(pm.price) || 0;
-  const pricePerUnit =
-    negEasy > 0 ? negEasy : negPrice > 0 ? negPrice : attrs.pricePerUnit ?? 0;
-  const start = pm.sqadualed ?? attrs.start ?? null;
-  const end = pm.sqadualedf ?? attrs.end ?? null;
+  const pricePerUnit = negEasy > 0 ? negEasy : negPrice;
+  const cycleSize = Number(pm.cycleSize) || 1;
+  const mashaabimId = pm.mashaabim?.data?.id;
   const now = new Date();
 
-  await strapi.execute(
-    'mrUpdateMashabetahalich',
+  const createRes: any = await strapi.execute(
+    'mrCreateMashabetahalich',
     {
-      id: draft.id,
       data: {
-        status_mashab: 'active',
+        name: resourceName,
+        project: projectId,
         users_permissions_user: acceptedUserId,
+        pmash: pmash.id,
+        ...(mashaabimId ? { mashaabim: mashaabimId } : {}),
+        kindOf,
+        unit,
+        status_mashab: 'active',
+        recurring: true,
+        cycleSize,
         pricePerUnit,
-        kindOf: kindOfFinal,
-        ...(start ? { start } : {}),
-        ...(end ? { end } : {}),
+        ...(pm.sqadualed ? { start: pm.sqadualed } : { start: now.toISOString() }),
+        ...(pm.sqadualedf ? { end: pm.sqadualedf } : {}),
+        finnished: false,
+        publishedAt: now.toISOString(),
       },
     },
     context.jwt,
     context.fetch
   );
+  const mashId = createRes?.data?.createMashabetahalich?.data?.id;
+  if (!mashId || !maapId) return;
 
-  if (maapId) {
-    const { cycleStart, cycleEnd } = currentCycleBounds(unit);
-    await strapi.execute(
-      'mrUpdateCycleMaap',
-      {
-        id: maapId,
-        data: {
-          mashabetahalich: draft.id,
-          cycleIndex: 1,
-          cycleStart,
-          cycleEnd,
-          quantityDelivered: pricePerUnit,
-          publishedAt: now.toISOString(),
-        },
+  const { cycleStart, cycleEnd } = currentCycleBounds(unit);
+  await strapi.execute(
+    'mrUpdateCycleMaap',
+    {
+      id: maapId,
+      data: {
+        mashabetahalich: mashId,
+        cycleIndex: 1,
+        cycleStart,
+        cycleEnd,
+        quantityDelivered: pricePerUnit,
+        publishedAt: now.toISOString(),
       },
-      context.jwt,
-      context.fetch
-    );
-  }
+    },
+    context.jwt,
+    context.fetch
+  );
 }
 
 export async function runResourceAskmAcceptance(

--- a/src/lib/server/actions/helpers/runResourceAskmAcceptance.ts
+++ b/src/lib/server/actions/helpers/runResourceAskmAcceptance.ts
@@ -81,13 +81,33 @@ export async function activateRecurringEngine(
   if (!draft) return;
 
   const attrs = draft.attributes ?? {};
-  const unit: 'month' | 'year' = attrs.kindOf === 'yearly' ? 'year' : 'month';
-  const pricePerUnit = attrs.pricePerUnit ?? 0;
+  // Prefer the final negotiated terms carried on the linked Pmash (members may
+  // have negotiated the monthly cost / period before approval) over the draft's
+  // initial values.
+  const pm = attrs.pmash?.data?.attributes ?? {};
+  const kindOfFinal = pm.kindOf ?? attrs.kindOf;
+  const unit: 'month' | 'year' = kindOfFinal === 'yearly' ? 'year' : 'month';
+  const negEasy = Number(pm.easy) || 0;
+  const negPrice = Number(pm.price) || 0;
+  const pricePerUnit =
+    negEasy > 0 ? negEasy : negPrice > 0 ? negPrice : attrs.pricePerUnit ?? 0;
+  const start = pm.sqadualed ?? attrs.start ?? null;
+  const end = pm.sqadualedf ?? attrs.end ?? null;
   const now = new Date();
 
   await strapi.execute(
     'mrUpdateMashabetahalich',
-    { id: draft.id, data: { status_mashab: 'active', users_permissions_user: acceptedUserId } },
+    {
+      id: draft.id,
+      data: {
+        status_mashab: 'active',
+        users_permissions_user: acceptedUserId,
+        pricePerUnit,
+        kindOf: kindOfFinal,
+        ...(start ? { start } : {}),
+        ...(end ? { end } : {}),
+      },
+    },
     context.jwt,
     context.fetch
   );

--- a/src/lib/server/actions/helpers/runResourceAskmAcceptance.ts
+++ b/src/lib/server/actions/helpers/runResourceAskmAcceptance.ts
@@ -42,6 +42,77 @@ function normalizeVotes(existingVotes: unknown[]) {
   }));
 }
 
+/** Month bounds for the cycle containing `ref`. */
+function currentCycleBounds(unit: 'month' | 'year', ref = new Date()) {
+  if (unit === 'year') {
+    return {
+      cycleStart: new Date(ref.getFullYear(), 0, 1).toISOString(),
+      cycleEnd: new Date(ref.getFullYear(), 11, 31, 23, 59, 59).toISOString(),
+    };
+  }
+  return {
+    cycleStart: new Date(ref.getFullYear(), ref.getMonth(), 1).toISOString(),
+    cycleEnd: new Date(ref.getFullYear(), ref.getMonth() + 1, 0, 23, 59, 59).toISOString(),
+  };
+}
+
+/**
+ * If a DRAFT recurring engine was created for this resource at proposal time
+ * (createResource, multi-member branch), activate it on approval: status →
+ * active, assign the responsible user, and turn the freshly-created acceptance
+ * Maap into cycle #1 (links it to the engine + sets the cycle window/amount).
+ * No-op for non-recurring resources.
+ */
+export async function activateRecurringEngine(
+  strapi: StrapiExecutor,
+  context: AcceptContext,
+  args: { projectId: string; resourceName: string; acceptedUserId: string; maapId?: string }
+): Promise<void> {
+  const { projectId, resourceName, acceptedUserId, maapId } = args;
+  if (!resourceName) return;
+
+  const res: any = await strapi.execute(
+    'mrGetDraftMashForProject',
+    { pid: projectId, name: resourceName },
+    context.jwt,
+    context.fetch
+  );
+  const draft = res?.data?.mashabetahaliches?.data?.[0];
+  if (!draft) return;
+
+  const attrs = draft.attributes ?? {};
+  const unit: 'month' | 'year' = attrs.kindOf === 'yearly' ? 'year' : 'month';
+  const pricePerUnit = attrs.pricePerUnit ?? 0;
+  const now = new Date();
+
+  await strapi.execute(
+    'mrUpdateMashabetahalich',
+    { id: draft.id, data: { status_mashab: 'active', users_permissions_user: acceptedUserId } },
+    context.jwt,
+    context.fetch
+  );
+
+  if (maapId) {
+    const { cycleStart, cycleEnd } = currentCycleBounds(unit);
+    await strapi.execute(
+      'mrUpdateCycleMaap',
+      {
+        id: maapId,
+        data: {
+          mashabetahalich: draft.id,
+          cycleIndex: 1,
+          cycleStart,
+          cycleEnd,
+          quantityDelivered: pricePerUnit,
+          publishedAt: now.toISOString(),
+        },
+      },
+      context.jwt,
+      context.fetch
+    );
+  }
+}
+
 export async function runResourceAskmAcceptance(
   strapi: StrapiExecutor,
   context: AcceptContext,
@@ -64,7 +135,7 @@ export async function runResourceAskmAcceptance(
   const fetchFn = context.fetch;
   const newnew = !existingMemberIds.map(String).includes(String(acceptedUserId));
 
-  await strapi.execute(
+  const maapRes: any = await strapi.execute(
     '141createMaap',
     {
       data: {
@@ -78,8 +149,17 @@ export async function runResourceAskmAcceptance(
     jwt,
     fetchFn
   );
+  const maapId = maapRes?.data?.createMaap?.data?.id;
 
   await strapi.execute('131archiveOpenMashaabim', { id: openMashaabimId }, jwt, fetchFn);
+
+  // Recurring expense? Activate the draft engine and make this Maap cycle #1.
+  await activateRecurringEngine(strapi, context, {
+    projectId,
+    resourceName: missionName,
+    acceptedUserId,
+    maapId,
+  });
 
   if (newnew) {
     await strapi.execute(

--- a/src/lib/server/notifications/EmailService.ts
+++ b/src/lib/server/notifications/EmailService.ts
@@ -124,6 +124,7 @@ export class EmailService {
         HalukaApproved: () => import('$lib/components/mail/HalukaApproved.svelte'),
         ComeVoteJoin: () => import('$lib/components/mail/comeVoteJoin.svelte'),
         MissionAccepted: () => import('$lib/components/mail/mail.svelte'),
+        MonthlyResourceActive: () => import('$lib/components/mail/monthlyResourceActive.svelte'),
       };
 
       const loader = templates[templateName];

--- a/src/lib/translations/ar/lev.json
+++ b/src/lib/translations/ar/lev.json
@@ -93,6 +93,13 @@
       "inTotal": "المجموع",
       "oneMonth": "شهر واحد"
     },
+    "resourcePeriod": {
+      "monthly": "شهري",
+      "yearly": "سنوي",
+      "recurring": "مورد متكرر",
+      "noEndDate": "بدون تاريخ انتهاء",
+      "months": "أشهر"
+    },
     "inpro": {
       "missionInProgress": "مهمة قيد التنفيذ",
       "progressStatus": "حالة تقدم تنفيذ المهمة",

--- a/src/lib/translations/en/lev.json
+++ b/src/lib/translations/en/lev.json
@@ -93,6 +93,13 @@
       "inTotal": "In total",
       "oneMonth": "One month"
     },
+    "resourcePeriod": {
+      "monthly": "Monthly",
+      "yearly": "Yearly",
+      "recurring": "Recurring resource",
+      "noEndDate": "No end date",
+      "months": "months"
+    },
     "inpro": {
       "missionInProgress": "Mission in progress",
       "progressStatus": "Status of mission progress",

--- a/src/lib/translations/he/lev.json
+++ b/src/lib/translations/he/lev.json
@@ -93,6 +93,13 @@
       "inTotal": "סך הכל",
       "oneMonth": "חודש אחד"
     },
+    "resourcePeriod": {
+      "monthly": "חודשי",
+      "yearly": "שנתי",
+      "recurring": "משאב חוזר",
+      "noEndDate": "ללא תאריך סיום",
+      "months": "חודשים"
+    },
     "inpro": {
       "missionInProgress": "משימה בתהליך ביצוע",
       "progressStatus": "סטטוס התקדמות ביצוע המשימה",

--- a/src/lib/translations/ru/lev.json
+++ b/src/lib/translations/ru/lev.json
@@ -93,6 +93,13 @@
       "inTotal": "Всего",
       "oneMonth": "Один месяц"
     },
+    "resourcePeriod": {
+      "monthly": "Ежемесячно",
+      "yearly": "Ежегодно",
+      "recurring": "Повторяющийся ресурс",
+      "noEndDate": "Без даты окончания",
+      "months": "месяцев"
+    },
     "inpro": {
       "missionInProgress": "Задача в процессе выполнения",
       "progressStatus": "Статус прогресса выполнения задачи",

--- a/src/lib/utils/levDataExtractors.ts
+++ b/src/lib/utils/levDataExtractors.ts
@@ -538,10 +538,16 @@ export function extractPmashes(userData: any): PendResourceData[] {
         timegramaId: pmash.attributes.timegrama?.data?.id,
         timegramaDate: pmash.attributes.timegrama?.data?.attributes?.date,
         nego_mashes: pmash.attributes.nego_mashes || { data: [] },
-        // Recurring expense flags
+        // Recurring expense flags. pricePerUnit reflects the LIVE (possibly
+        // negotiated) monthly cost — the pmash's easy/price take precedence over
+        // the engine's initial pricePerUnit so negotiation shows immediately.
         recurring: isRecurring,
         recurringNoEnd: isRecurring && !recurringEnd,
-        pricePerUnit: engine?.pricePerUnit ?? pmash.attributes.easy ?? pmash.attributes.price ?? 0
+        pricePerUnit:
+          pmash.attributes.easy ||
+          pmash.attributes.price ||
+          engine?.pricePerUnit ||
+          0
       });
     }
   }

--- a/src/lib/utils/levDataExtractors.ts
+++ b/src/lib/utils/levDataExtractors.ts
@@ -509,10 +509,9 @@ export function extractPmashes(userData: any): PendResourceData[] {
         continue;
       }
 
-      // Recurring expense? (a draft mashabetahalich engine is linked to the pmash)
-      const engine = pmash.attributes.mashabetahaliches?.data?.[0]?.attributes;
-      const isRecurring = Boolean(engine?.recurring);
-      const recurringEnd = engine?.end ?? pmash.attributes.sqadualedf ?? null;
+      // Recurring expense? The flag lives on the Pmash so it stays negotiable.
+      const isRecurring = Boolean(pmash.attributes.recurring);
+      const recurringEnd = pmash.attributes.sqadualedf ?? null;
 
       pmashes.push({
         id: pmash.id,
@@ -538,16 +537,12 @@ export function extractPmashes(userData: any): PendResourceData[] {
         timegramaId: pmash.attributes.timegrama?.data?.id,
         timegramaDate: pmash.attributes.timegrama?.data?.attributes?.date,
         nego_mashes: pmash.attributes.nego_mashes || { data: [] },
-        // Recurring expense flags. pricePerUnit reflects the LIVE (possibly
-        // negotiated) monthly cost — the pmash's easy/price take precedence over
-        // the engine's initial pricePerUnit so negotiation shows immediately.
+        // Recurring expense flags. pricePerUnit is the LIVE (possibly negotiated)
+        // per-cycle cost taken straight from the pmash's easy/price.
         recurring: isRecurring,
         recurringNoEnd: isRecurring && !recurringEnd,
-        pricePerUnit:
-          pmash.attributes.easy ||
-          pmash.attributes.price ||
-          engine?.pricePerUnit ||
-          0
+        cycleSize: pmash.attributes.cycleSize ?? 1,
+        pricePerUnit: pmash.attributes.easy || pmash.attributes.price || 0
       });
     }
   }

--- a/src/lib/utils/levDataExtractors.ts
+++ b/src/lib/utils/levDataExtractors.ts
@@ -565,35 +565,51 @@ export function extractWegets(userData: any): ResourceRequestData[] {
           continue;
         }
 
+        // Recurring monthly resource cycle? (Maap linked to a mashabetahalich engine)
+        const mashab = maap.attributes.mashabetahalich?.data;
+        const mashabAttrs = mashab?.attributes;
+        const isRecurringCycle = Boolean(mashab?.id);
+
         wegets.push({
           id: maap.id,
           projectId: project.id,
           requestType: 'maap',
           priority: 6,
           // Additional fields
-          name: maap.attributes.name || '',
+          name: maap.attributes.name || mashabAttrs?.name || '',
           createdAt: maap.attributes.createdAt,
           vots: maap.attributes.vots || [],
           spId: maap.attributes.sp?.data?.id,
           spData: maap.attributes.sp?.data?.attributes,
-          spName: maap.attributes.sp?.data?.attributes?.name,
+          spName: maap.attributes.sp?.data?.attributes?.name || mashabAttrs?.name,
           openMashaabimId: maap.attributes.open_mashaabim?.data?.id,
           openMashaabimData: maap.attributes.open_mashaabim?.data?.attributes,
           users: maap.attributes.vots || [],
           src: maap.attributes.project?.data?.attributes?.profilePic?.data?.attributes?.url || 'https://res.cloudinary.com/love1/image/upload/v1653053361/image_s1syn2.png',
           // Extract fields from open_mashaabim
           easy: maap.attributes.open_mashaabim?.data?.attributes?.easy,
-          price: maap.attributes.open_mashaabim?.data?.attributes?.price,
+          price: maap.attributes.open_mashaabim?.data?.attributes?.price ?? mashabAttrs?.pricePerUnit,
           sqadualed: maap.attributes.open_mashaabim?.data?.attributes?.sqadualed,
           sqadualedf: maap.attributes.open_mashaabim?.data?.attributes?.sqadualedf,
           spnot: maap.attributes.open_mashaabim?.data?.attributes?.spnot,
-          kindOf: maap.attributes.open_mashaabim?.data?.attributes?.kindOf,
+          kindOf: maap.attributes.open_mashaabim?.data?.attributes?.kindOf ?? mashabAttrs?.kindOf,
           unit: maap.attributes.sp?.data?.attributes?.unit,
-          openName: maap.attributes.open_mashaabim?.data?.attributes?.name,
-          userId: maap.attributes.sp?.data?.attributes?.users_permissions_user?.data?.id,
+          openName: maap.attributes.open_mashaabim?.data?.attributes?.name || mashabAttrs?.name,
+          userId:
+            maap.attributes.sp?.data?.attributes?.users_permissions_user?.data?.id ||
+            mashabAttrs?.users_permissions_user?.data?.id,
           username: maap.attributes.sp?.data?.attributes?.users_permissions_user?.data?.attributes?.username,
           myp: maap.attributes.sp?.data?.attributes?.myp,
-          myid: userData.id
+          myid: userData.id,
+          // Recurring cycle fields (only present on recurring cycle Maaps)
+          isRecurringCycle,
+          mashabetahalichId: mashab?.id,
+          cycleIndex: maap.attributes.cycleIndex,
+          cycleStart: maap.attributes.cycleStart,
+          cycleEnd: maap.attributes.cycleEnd,
+          quantityDelivered: maap.attributes.quantityDelivered,
+          pricePerUnit: mashabAttrs?.pricePerUnit,
+          responsibleUserId: mashabAttrs?.users_permissions_user?.data?.id
         });
       }
     }

--- a/src/lib/utils/levDataExtractors.ts
+++ b/src/lib/utils/levDataExtractors.ts
@@ -509,6 +509,11 @@ export function extractPmashes(userData: any): PendResourceData[] {
         continue;
       }
 
+      // Recurring expense? (a draft mashabetahalich engine is linked to the pmash)
+      const engine = pmash.attributes.mashabetahaliches?.data?.[0]?.attributes;
+      const isRecurring = Boolean(engine?.recurring);
+      const recurringEnd = engine?.end ?? pmash.attributes.sqadualedf ?? null;
+
       pmashes.push({
         id: pmash.id,
         projectId: project.id,
@@ -532,7 +537,11 @@ export function extractPmashes(userData: any): PendResourceData[] {
         mashaabimId: pmash.attributes.mashaabim?.data?.id,
         timegramaId: pmash.attributes.timegrama?.data?.id,
         timegramaDate: pmash.attributes.timegrama?.data?.attributes?.date,
-        nego_mashes: pmash.attributes.nego_mashes || { data: [] }
+        nego_mashes: pmash.attributes.nego_mashes || { data: [] },
+        // Recurring expense flags
+        recurring: isRecurring,
+        recurringNoEnd: isRecurring && !recurringEnd,
+        pricePerUnit: engine?.pricePerUnit ?? pmash.attributes.easy ?? pmash.attributes.price ?? 0
       });
     }
   }

--- a/src/lib/utils/levProcessors.ts
+++ b/src/lib/utils/levProcessors.ts
@@ -1481,6 +1481,11 @@ export function processPmashes(
       sqadualed: pmash.sqadualed,
       sqadualedf: pmash.sqadualedf,
 
+      // Recurring expense flags (open-ended monthly/yearly cost, approved monthly)
+      recurring: pmash.recurring === true,
+      recurringNoEnd: pmash.recurringNoEnd === true,
+      pricePerUnit: pmash.pricePerUnit,
+
       // Timegrama
       timegramaId: pmash.timegramaId,
       timeGramaDate: pmash.timegramaDate,

--- a/src/lib/utils/levProcessors.ts
+++ b/src/lib/utils/levProcessors.ts
@@ -1484,6 +1484,7 @@ export function processPmashes(
       // Recurring expense flags (open-ended monthly/yearly cost, approved monthly)
       recurring: pmash.recurring === true,
       recurringNoEnd: pmash.recurringNoEnd === true,
+      cycleSize: pmash.cycleSize ?? 1,
       pricePerUnit: pmash.pricePerUnit,
 
       // Timegrama

--- a/src/lib/utils/levProcessors.ts
+++ b/src/lib/utils/levProcessors.ts
@@ -1643,7 +1643,17 @@ export function processWegets(
       noofusersNo,
       whyno,
       whyes,
-      noofusersWaiting
+      noofusersWaiting,
+
+      // Recurring monthly resource cycle fields
+      isRecurringCycle: weget.isRecurringCycle === true,
+      mashabetahalichId: weget.mashabetahalichId,
+      cycleIndex: weget.cycleIndex,
+      cycleStart: weget.cycleStart,
+      cycleEnd: weget.cycleEnd,
+      quantityDelivered: weget.quantityDelivered,
+      pricePerUnit: weget.pricePerUnit,
+      responsibleUserId: weget.responsibleUserId
     };
   });
 }

--- a/src/routes/api/monthi/+server.js
+++ b/src/routes/api/monthi/+server.js
@@ -14,6 +14,68 @@ function formatDate(date = new Date()) {
   return [year, month, day].join('-');
 }
 
+// Bounds of the cycle (month or year) that contains `ref`.
+function cycleBounds(unit, ref = new Date()) {
+  if (unit === 'year') {
+    return {
+      cycleStart: new Date(ref.getFullYear(), 0, 1),
+      cycleEnd: new Date(ref.getFullYear(), 11, 31, 23, 59, 59)
+    };
+  }
+  return {
+    cycleStart: new Date(ref.getFullYear(), ref.getMonth(), 1),
+    cycleEnd: new Date(ref.getFullYear(), ref.getMonth() + 1, 0, 23, 59, 59)
+  };
+}
+
+// Does an existing (non-archived) cycle already cover the given window?
+function hasOpenCycleFor(maaps, cycleStart) {
+  const y = cycleStart.getFullYear();
+  const m = cycleStart.getMonth();
+  return (maaps || []).some((mp) => {
+    const a = mp.attributes ?? mp;
+    if (a.archived) return false;
+    if (!a.cycleStart) return false;
+    const d = new Date(a.cycleStart);
+    return d.getFullYear() === y && d.getMonth() === m;
+  });
+}
+
+// Render the activation email and post it to the existing sendMail endpoint.
+async function sendActivationEmail(fetchFn, user, payload) {
+  if (!user?.email || user?.noMail === true) return;
+  try {
+    const { render } = await import('svelty-email');
+    const mod = await import('$lib/components/mail/monthlyResourceActive.svelte');
+    const lang = ['he', 'en', 'ar'].includes(user.lang) ? user.lang : 'he';
+    const previewText =
+      lang === 'en'
+        ? `Log this month's expense for ${payload.resourceName}`
+        : `עדכון ההוצאה החודשית עבור ${payload.resourceName}`;
+    const emailHtml = await render(mod.default, {
+      username: user.username || '',
+      resourceName: payload.resourceName,
+      projectName: payload.projectName,
+      plannedAmount: payload.plannedAmount,
+      monthLabel: payload.monthLabel,
+      lang,
+      previewText
+    });
+    await fetchFn('/api/sendMail', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        email: user.email,
+        emailHtml,
+        previewText,
+        emailText: previewText
+      })
+    });
+  } catch (e) {
+    console.error('monthi: failed to send activation email', e);
+  }
+}
+
 // Hours from timer segments that fall within the given year+month
 function hoursInMonth(timers, year, month) {
   if (!timers || !Array.isArray(timers)) return 0;
@@ -33,7 +95,7 @@ function hoursInMonth(timers, year, month) {
 
 let suc = [];
 
-export async function GET() {
+export async function GET({ fetch }) {
   console.log('monthi api called');
   suc = [];
 
@@ -129,5 +191,103 @@ export async function GET() {
     console.error('monthi top-level error', e);
   }
 
-  return new Response(JSON.stringify(suc));
+  // ── Recurring resources (mashabetahalich): open this month's cycle ─────────
+  const sucRes = await runRecurringResources(fetch);
+
+  return new Response(JSON.stringify({ missions: suc, resources: sucRes }));
+}
+
+// For every active recurring resource, open a Maap cycle for the current month
+// (unless one already exists or the resource ended), and email the responsible
+// user to confirm the amount spent. Past-end resources are closed.
+async function runRecurringResources(fetchFn) {
+  const opened = [];
+
+  const listQue = `query MrGetRecurringForMonthi {
+    mashabetahaliches(
+      filters: { recurring: { eq: true }, status_mashab: { eq: "active" }, finnished: { eq: false } }
+      pagination: { limit: 300 }
+    ) {
+      data { id attributes {
+        name pricePerUnit start end cycleSize kindOf
+        project { data { id attributes { projectName } } }
+        users_permissions_user { data { id attributes { username email lang noMail } } }
+        maaps(pagination: { limit: 500 }) { data { id attributes { cycleIndex cycleStart cycleEnd archived } } }
+      } }
+    }
+  }`;
+
+  let list;
+  try {
+    list = await SendTo(listQue, ADMINMONTHER);
+  } catch (e) {
+    console.error('monthi: failed to list recurring resources', e);
+    return opened;
+  }
+  const engines = list?.data?.mashabetahaliches?.data ?? [];
+  const now = new Date();
+
+  for (const eng of engines) {
+    const id = eng.id;
+    const a = eng.attributes ?? {};
+    try {
+      const unit = a.kindOf === 'yearly' ? 'year' : 'month';
+      const start = a.start ? new Date(a.start) : null;
+      const end = a.end ? new Date(a.end) : null;
+
+      if (start && now < start) continue; // not started yet
+
+      if (end && now > end) {
+        // Past the end date — close the engine so no further cycles open.
+        const closeMut = `mutation { updateMashabetahalich(id: "${id}", data: { status_mashab: "closed", finnished: true }) { data { id } } }`;
+        await SendTo(closeMut, ADMINMONTHER);
+        continue;
+      }
+
+      const { cycleStart, cycleEnd } = cycleBounds(unit, now);
+      const maaps = a.maaps?.data ?? [];
+      if (hasOpenCycleFor(maaps, cycleStart)) continue; // already opened this period
+
+      const nextIndex =
+        maaps.reduce((mx, mp) => Math.max(mx, mp.attributes?.cycleIndex ?? 0), 0) + 1;
+      const projectId = a.project?.data?.id;
+      const planned = a.pricePerUnit ?? 0;
+      const name = (a.name ?? 'משאב').replace(/"/g, '\\"');
+
+      const createMut = `mutation {
+        createMaap(data: {
+          project: "${projectId}",
+          name: "${name}",
+          mashabetahalich: "${id}",
+          cycleIndex: ${nextIndex},
+          cycleStart: "${cycleStart.toISOString()}",
+          cycleEnd: "${cycleEnd.toISOString()}",
+          quantityDelivered: ${planned},
+          publishedAt: "${now.toISOString()}"
+        }) { data { id } }
+      }`;
+      const created = await SendTo(createMut, ADMINMONTHER);
+      if (!created?.data?.createMaap?.data?.id) {
+        console.error('monthi: failed to open cycle for resource', id, created);
+        continue;
+      }
+
+      // Email the responsible user to confirm this month's spend.
+      const user = a.users_permissions_user?.data?.attributes;
+      const monthLabel = `${String(now.getMonth() + 1).padStart(2, '0')}/${now.getFullYear()}`;
+      await sendActivationEmail(fetchFn, user, {
+        resourceName: a.name ?? '',
+        projectName: a.project?.data?.attributes?.projectName ?? '',
+        plannedAmount: planned,
+        monthLabel
+      });
+
+      console.log('monthi: opened cycle', nextIndex, 'for resource', id);
+      opened.push(id);
+    } catch (e) {
+      console.error('monthi: error processing recurring resource', id, e);
+    }
+  }
+
+  return opened;
 }

--- a/src/routes/api/send/qids.js
+++ b/src/routes/api/send/qids.js
@@ -3744,6 +3744,18 @@ mutation UpdateProjectProfilePic($projectId: ID!, $imageId: ID!) {
                         id
                       }
                     }
+                    mashabetahaliches(filters: { recurring: { eq: true } }) {
+                      data {
+                        id
+                        attributes {
+                          recurring
+                          pricePerUnit
+                          start
+                          end
+                          status_mashab
+                        }
+                      }
+                    }
                     timegrama {
                       data {
                         id

--- a/src/routes/api/send/qids.js
+++ b/src/routes/api/send/qids.js
@@ -7457,7 +7457,10 @@ export const moachQids = {
       }
       pagination: { limit: 1 }
     ) {
-      data { id attributes { pricePerUnit kindOf start end cycleSize } }
+      data { id attributes {
+        pricePerUnit kindOf start end cycleSize
+        pmash { data { id attributes { easy price sqadualed sqadualedf kindOf } } }
+      } }
     }
   }`,
   'mrUpdateCycleMaap': `mutation MrUpdateCycleMaap($id: ID!, $data: MaapInput!) {

--- a/src/routes/api/send/qids.js
+++ b/src/routes/api/send/qids.js
@@ -2095,6 +2095,23 @@ mutation UpdateProjectProfilePic($projectId: ID!, $imageId: ID!) {
         id
         attributes {
           name
+          quantityDelivered
+          cycleIndex
+          cycleStart
+          cycleEnd
+          mashabetahalich {
+            data {
+              id
+              attributes {
+                name
+                pricePerUnit
+                kindOf
+                quantityDelivered
+                users_permissions_user { data { id } }
+                rikmash { data { id } }
+              }
+            }
+          }
           vots {
             id
             what
@@ -3600,6 +3617,24 @@ mutation UpdateProjectProfilePic($projectId: ID!, $imageId: ID!) {
                   attributes {
                     createdAt
                     name
+                    quantityDelivered
+                    cycleIndex
+                    cycleStart
+                    cycleEnd
+                    mashabetahalich {
+                      data {
+                        id
+                        attributes {
+                          name
+                          pricePerUnit
+                          kindOf
+                          start
+                          end
+                          status_mashab
+                          users_permissions_user { data { id } }
+                        }
+                      }
+                    }
                     sp {
                       data {
                         id
@@ -7339,6 +7374,84 @@ mutation UpdateProjectProfilePic($projectId: ID!, $imageId: ID!) {
 };
 
 export const moachQids = {
+  // ─── Monthly recurring resources (mashabetahalich cyclic engine) ──────────
+  // A "mashabetahalich" with recurring=true is a recurring expense (server rent,
+  // apartment, stall…). Each month /api/monthi opens a cycle (a Maap with
+  // cycleIndex/cycleStart/cycleEnd) that surfaces on the lev screen; once the
+  // responsible user confirms the amount and the project approves it, the spend
+  // is archived as a delivery line on the resource's Rikmash.
+  'mrCreateMashabetahalich': `mutation MrCreateMashabetahalich($data: MashabetahalichInput!) {
+    createMashabetahalich(data: $data) { data { id attributes { name } } }
+  }`,
+  'mrUpdateMashabetahalich': `mutation MrUpdateMashabetahalich($id: ID!, $data: MashabetahalichInput!) {
+    updateMashabetahalich(id: $id, data: $data) { data { id attributes { status_mashab finnished } } }
+  }`,
+  'mrGetMashabetahalich': `query MrGetMashabetahalich($id: ID!) {
+    mashabetahalich(id: $id) {
+      data { id attributes {
+        name descrip pricePerUnit start end cycleSize kindOf recurring status_mashab
+        finnished quantityDelivered
+        project { data { id attributes { user_1s { data { id } } } } }
+        users_permissions_user { data { id attributes { username email lang noMail } } }
+        maaps { data { id attributes { cycleIndex cycleStart cycleEnd archived } } }
+        rikmash { data { id } }
+      } }
+    }
+  }`,
+  // Used by /api/monthi: every active, non-finished recurring resource.
+  'mrGetRecurringForMonthi': `query MrGetRecurringForMonthi {
+    mashabetahaliches(
+      filters: { recurring: { eq: true }, status_mashab: { eq: "active" }, finnished: { eq: false } }
+      pagination: { limit: 300 }
+    ) {
+      data { id attributes {
+        name pricePerUnit start end cycleSize kindOf
+        project { data { id attributes { projectName user_1s { data { id } } } } }
+        users_permissions_user { data { id attributes { username email lang noMail } } }
+        maaps(pagination: { limit: 500 }) { data { id attributes { cycleIndex cycleStart cycleEnd archived } } }
+        rikmash { data { id } }
+      } }
+    }
+  }`,
+  'mrCreateCycleMaap': `mutation MrCreateCycleMaap($data: MaapInput!) {
+    createMaap(data: $data) { data { id attributes { cycleIndex } } }
+  }`,
+  'mrGetRikmashForDelivery': `query MrGetRikmashForDelivery($id: ID!) {
+    rikmash(id: $id) {
+      data { id attributes {
+        total cyclesCount firstDeliveryAt lastDeliveryAt
+        deliveries { id cycleIndex deliveredAt quantity note maap { data { id } } }
+      } }
+    }
+  }`,
+  'mrCreateRikmash': `mutation MrCreateRikmash($data: RikmashInput!) {
+    createRikmash(data: $data) { data { id } }
+  }`,
+  'mrUpdateRikmash': `mutation MrUpdateRikmash($id: ID!, $data: RikmashInput!) {
+    updateRikmash(id: $id, data: $data) { data { id } }
+  }`,
+  'mrLinkRikmashToMashabetahalich': `mutation MrLinkRikmash($id: ID!, $rikmash: ID!) {
+    updateMashabetahalich(id: $id, data: { rikmash: $rikmash }) { data { id } }
+  }`,
+  // Resolve a DRAFT recurring engine created at proposal time, so askm approval
+  // can activate it. Matched by project + name (robust to the pmash→om linkage).
+  'mrGetDraftMashForProject': `query MrGetDraftMashForProject($pid: ID!, $name: String!) {
+    mashabetahaliches(
+      filters: {
+        project: { id: { eq: $pid } }
+        recurring: { eq: true }
+        status_mashab: { eq: "draft" }
+        name: { eq: $name }
+      }
+      pagination: { limit: 1 }
+    ) {
+      data { id attributes { pricePerUnit kindOf start end cycleSize } }
+    }
+  }`,
+  'mrUpdateCycleMaap': `mutation MrUpdateCycleMaap($id: ID!, $data: MaapInput!) {
+    updateMaap(id: $id, data: $data) { data { id } }
+  }`,
+
   'getProjectBaseInfo': `query GetProjectBaseInfo($pid: ID!) {
     project(id: $pid) {
       data {

--- a/src/routes/api/send/qids.js
+++ b/src/routes/api/send/qids.js
@@ -3702,6 +3702,8 @@ mutation UpdateProjectProfilePic($projectId: ID!, $imageId: ID!) {
                     price
                     kindOf
                     spnot
+                    recurring
+                    cycleSize
                     location {
                       location_mode
                       lat
@@ -3742,18 +3744,6 @@ mutation UpdateProjectProfilePic($projectId: ID!, $imageId: ID!) {
                     mashaabim {
                       data {
                         id
-                      }
-                    }
-                    mashabetahaliches(filters: { recurring: { eq: true } }) {
-                      data {
-                        id
-                        attributes {
-                          recurring
-                          pricePerUnit
-                          start
-                          end
-                          status_mashab
-                        }
                       }
                     }
                     timegrama {
@@ -7359,7 +7349,7 @@ mutation UpdateProjectProfilePic($projectId: ID!, $imageId: ID!) {
     $isOriginal: Boolean, $name: String, $descrip: String, $spnot: String,
     $easy: Float, $hm: Float, $price: Float, $kindOf: ENUM_NEGOMASH_KINDOF,
     $sqadualed: DateTime, $sqadualedf: DateTime, $linkto: String,
-    $location: [ComponentNewLocationInput]
+    $location: [ComponentNewLocationInput], $recurring: Boolean, $cycleSize: Int
   ) {
     createNegoMash(data: {
       publishedAt: $publishedAt
@@ -7377,6 +7367,8 @@ mutation UpdateProjectProfilePic($projectId: ID!, $imageId: ID!) {
       sqadualedf: $sqadualedf
       linkto: $linkto
       location: $location
+      recurring: $recurring
+      cycleSize: $cycleSize
     }) { data { id } }
   }`,
 
@@ -7445,21 +7437,23 @@ export const moachQids = {
   'mrLinkRikmashToMashabetahalich': `mutation MrLinkRikmash($id: ID!, $rikmash: ID!) {
     updateMashabetahalich(id: $id, data: { rikmash: $rikmash }) { data { id } }
   }`,
-  // Resolve a DRAFT recurring engine created at proposal time, so askm approval
-  // can activate it. Matched by project + name (robust to the pmash→om linkage).
-  'mrGetDraftMashForProject': `query MrGetDraftMashForProject($pid: ID!, $name: String!) {
-    mashabetahaliches(
+  // Resolve the approved recurring Pmash's final (possibly negotiated) terms so
+  // askm approval can spin up the mashabetahalich engine. Matched by project +
+  // name; only returns when the final pmash is still flagged recurring, so a
+  // member negotiating recurring → false cleanly results in no engine.
+  'mrGetPmashRecurringTerms': `query MrGetPmashRecurringTerms($pid: ID!, $name: String!) {
+    pmashes(
       filters: {
         project: { id: { eq: $pid } }
-        recurring: { eq: true }
-        status_mashab: { eq: "draft" }
         name: { eq: $name }
+        recurring: { eq: true }
       }
+      sort: ["createdAt:desc"]
       pagination: { limit: 1 }
     ) {
       data { id attributes {
-        pricePerUnit kindOf start end cycleSize
-        pmash { data { id attributes { easy price sqadualed sqadualedf kindOf } } }
+        recurring cycleSize easy price kindOf sqadualed sqadualedf
+        mashaabim { data { id } }
       } }
     }
   }`,

--- a/src/routes/api/send/qids.js
+++ b/src/routes/api/send/qids.js
@@ -3726,6 +3726,8 @@ mutation UpdateProjectProfilePic($projectId: ID!, $imageId: ID!) {
                           price
                           kindOf
                           spnot
+                          recurring
+                          cycleSize
                           location {
                             location_mode
                             lat


### PR DESCRIPTION
Adds recurring monthly/yearly expenses (server rent, apartment, stall) that run on a cyclic mashabetahalich engine driven by /api/monthi.

- ResourceCreator: "recurring monthly expense" toggle (end date optional = runs until marked done).
- createResource: single-member activates the engine immediately + opens cycle #1; multi-member carries a draft engine on the Pmash.
- finalizeAskmAcceptance / runResourceAskmAcceptance: on askm approval, activate the draft engine, assign the responsible user and turn the acceptance Maap into cycle #1.
- /api/monthi: each month opens the next cycle Maap (surfaces as an active card on the lev screen) and emails the responsible user to confirm the amount spent; closes the engine past its end date.
- voteOnMaap: recurring cycle Maaps confirm/edit the month's amount as a YES vote; on project consensus the spend is archived as a delivery line on the resource's Rikmash (created on the first cycle).
- markResourceDone: closes the engine (stops future cycles, archives).
- lev card: cycle amount entry, approval, and "mark done" controls; designed monthlyResourceActive email template.

No Strapi schema changes required — uses the existing cyclic-resource fields (mashabetahalich.recurring/status_mashab/start/end/pricePerUnit, maap.cycle*, rikmash.deliveries).