### PR TITLE
Add co-member + exact-lookup queries for private meeting participant selection

### DIFF
--- a/readmes/GUEST_INVITE_MEETING_IMPORT.md
+++ b/readmes/GUEST_INVITE_MEETING_IMPORT.md
@@ -1,0 +1,141 @@
+# Guest meeting invitations & post‑registration import
+
+This documents the **email‑bound guest invitation** flow that spans the two
+repos (`magik-meetings` = the meetings front‑end, `1.0` = the main site / API),
+and — importantly — **exactly what, if anything, needs to change in Strapi**.
+
+## TL;DR on Strapi
+
+**The implemented flow requires _no new Strapi content‑types._** It reuses the
+existing `pgishauserpend` (pending meeting participant) collection. Invitations
+are stateless, HMAC‑signed tokens — nothing is persisted upstream to create or
+verify them.
+
+The only hard requirement is an **env var** (`GUEST_INVITE_SECRET`), see below.
+
+An **optional** hardened design (persistent, revocable, auditable guest tokens)
+is described at the end — those content‑types are already referenced by
+`magik-meetings/src/routes/api/send/qids.js` but are **not** required for the
+current implementation.
+
+---
+
+## How the implemented flow works
+
+1. **Create meeting → invite by email** (`magik-meetings`)
+   The meeting creator enters an invitee's email in the invitation UI.
+   `POST /api/guest/invite` mints a signed token
+   `base64url({ v, m: meetingId, e: email, n: name, exp }) . HMAC‑SHA256` and
+   returns a link `…/meeting/invite/<token>`.
+
+2. **Guest opens the link** (`magik-meetings`)
+   `/meeting/invite/[token]` verifies the signature + expiry, then stores
+   `displayName, meetingId, email, inviteToken, expiresAt` in the local
+   `guest_info` cookie. The guest gets local meeting memory + online/offline
+   (already existing guest behaviour).
+
+3. **Guest chooses to register** (`magik-meetings` → `1.0`)
+   The register CTA links to `https://1lev1.com/hascama?invite=<token>`
+   (carrying the original signed token).
+
+4. **Token captured at /hascama** (`1.0`)
+   `src/routes/hascama/+page.server.js` stashes `?invite` into a short‑lived
+   `invite_token` cookie (the onboarding UI is client‑driven and hops to
+   `/signup`, so a cookie survives the hops).
+
+5. **Import after signup** (`1.0`)
+   `src/routes/signup/+page.server.js`, after creating the account, calls
+   `importInvitedMeeting()` which:
+   - verifies the token (`src/lib/server/guestInvite.ts`),
+   - checks the **registered email === the invited email**,
+   - creates a `pgishauserpend` for the new user via qid `19CreatePendMeeting`.
+   The meeting then appears in the user's pending‑invitations list
+   (`53GetPendingMeetings`) to approve. Best‑effort: signup never fails if the
+   import fails.
+
+Security: because the token is signed and email‑bound, a user cannot import a
+meeting they weren't invited to — they'd need a valid signature for their own
+email. Plain `invite_meeting`/`email` params (legacy fallback) are **not**
+auto‑imported.
+
+---
+
+## Required configuration (both apps)
+
+| Env var              | Where            | Notes |
+| -------------------- | ---------------- | ----- |
+| `GUEST_INVITE_SECRET`| `1.0` **and** `magik-meetings` | Must be the **same** value in both. Used to sign (meetings app) and verify (main site) invitation tokens. If unset, both fall back to the same dev‑only literal — fine for local dev, **must be set in production**. |
+
+`ADMINMONTHER` (already configured) is reused by `importInvitedMeeting` as the
+admin token for the `createPgishauserpend` write.
+
+---
+
+## Strapi — required content‑types
+
+**None new.** The flow only needs the existing collections, unchanged:
+
+### `pgishauserpend` (already exists)
+Fields already used by the app (`qids.js` 19/53/54):
+
+| Field                    | Type                              | Used for |
+| ------------------------ | --------------------------------- | -------- |
+| `users_permissions_user` | relation → `users-permissions.user` | who is invited |
+| `pgisha`                 | relation → `pgisha`               | which meeting |
+| `approved`               | boolean                           | invitee accepted |
+| `archived`               | boolean                           | hidden from pending list |
+
+No changes needed here — the import creates a row with
+`{ users_permissions_user, pgisha }`.
+
+---
+
+## OPTIONAL — persistent guest tokens (future hardening)
+
+The current tokens are stateless (can't be revoked before expiry, and there's
+no server‑side audit of who joined as a guest). If you later want revocable,
+auditable guest sessions, add the content‑types below. They match the queries
+already present (but presently unused) in
+`magik-meetings/src/routes/api/send/qids.js` (`createGuestToken`,
+`findGuestTokenByToken`, `createGuestSession`, `getGuestPgishausers`, …).
+
+### New collection: `guest-token`
+
+| Field         | Strapi type | Required | Notes |
+| ------------- | ----------- | -------- | ----- |
+| `token`       | UID / Text  | yes      | the random token string; index/unique |
+| `email`       | Email       | yes      | **the invited email (email‑binding)** |
+| `meeting`     | Relation (many‑to‑one → `pgisha`) | yes | invited to this meeting |
+| `invited_by`  | Relation (many‑to‑one → `users-permissions.user`) | no | the inviter |
+| `display_name`| Text        | no       | optional prefilled guest name |
+| `permissions` | JSON        | no       | `{ canSendMessages, canJoinVideo, … }` |
+| `expires_at`  | DateTime    | yes      | expiry |
+| `revoked_at`  | DateTime    | no       | set to revoke before expiry |
+| `last_used_at`| DateTime    | no       | audit |
+| `ip_address`  | Text        | no       | audit |
+| `user_agent`  | Text (long) | no       | audit |
+
+### New collection: `guest-session`
+
+| Field             | Strapi type | Required | Notes |
+| ----------------- | ----------- | -------- | ----- |
+| `session_id`      | UID / Text  | yes      | unique per session; index |
+| `guest_token`     | Relation (many‑to‑one → `guest-token`) | yes | parent token |
+| `is_active`       | Boolean     | yes      | default true |
+| `expires_at`      | DateTime    | yes      | |
+| `last_activity_at`| DateTime    | no       | |
+| `socket_id`       | Text        | no       | live socket correlation |
+| `display_name`    | Text        | no       | |
+| `permissions`     | JSON        | no       | snapshot |
+
+### Change to existing `pgishauser`
+
+| Field         | Strapi type | Notes |
+| ------------- | ----------- | ----- |
+| `guest_token` | Relation (many‑to‑one → `guest-token`) | lets `getGuestPgishausers` list the meetings a guest joined, for import/migration |
+
+With these in place, the migration queries already written in the meetings app
+(`getGuestPgishausers`, `getGuestMeetingHistory`, `associateGuestWithMeeting`)
+can import **all** of a guest's meetings on registration (not just the single
+invited one), and tokens become revocable. Until then, the stateless flow above
+covers the primary use case with zero Strapi changes.

--- a/src/lib/server/guestInvite.ts
+++ b/src/lib/server/guestInvite.ts
@@ -1,0 +1,91 @@
+/**
+ * Verification for email-bound guest invitation tokens minted by the meetings
+ * app (magik-meetings `src/lib/server/guestInvite.js`).
+ *
+ * The meetings app signs a self-contained token so a guest can be invited by
+ * email without any upstream write. After the invited person registers here on
+ * the main site, we verify that same token and import the meeting into their
+ * new account — but only if the token's signature is valid, it hasn't expired,
+ * and the registered email matches the invited email.
+ *
+ * IMPORTANT: `GUEST_INVITE_SECRET` must be set to the *same* value in both this
+ * app and the meetings app, otherwise signatures won't match. The dev fallback
+ * is shared verbatim between the two.
+ */
+
+import crypto from 'node:crypto';
+import { env } from '$env/dynamic/private';
+
+const SECRET =
+  env.GUEST_INVITE_SECRET || 'dev-only-insecure-guest-invite-secret-change-me';
+
+/** @param payloadB64 base64url-encoded payload */
+function sign(payloadB64: string): string {
+  return crypto
+    .createHmac('sha256', SECRET)
+    .update(payloadB64)
+    .digest('base64url');
+}
+
+/** A signed token is `base64url(payload).base64url(signature)`. */
+export function isSignedToken(token: unknown): token is string {
+  return typeof token === 'string' && token.split('.').length === 2;
+}
+
+export interface InvitePayload {
+  meetingId: string;
+  email: string;
+  meetingName: string;
+  expiresAt: string;
+}
+
+export interface VerifyResult {
+  valid: boolean;
+  error?: 'unsigned' | 'bad_signature' | 'malformed' | 'expired';
+  payload?: InvitePayload;
+}
+
+/** Verify and decode a signed invitation token. */
+export function verifyInviteToken(token: string): VerifyResult {
+  if (!isSignedToken(token)) {
+    return { valid: false, error: 'unsigned' };
+  }
+
+  const [payloadB64, sig] = token.split('.');
+
+  // Constant-time signature comparison.
+  const expected = sign(payloadB64);
+  const sigBuf = Buffer.from(sig);
+  const expBuf = Buffer.from(expected);
+  if (
+    sigBuf.length !== expBuf.length ||
+    !crypto.timingSafeEqual(sigBuf, expBuf)
+  ) {
+    return { valid: false, error: 'bad_signature' };
+  }
+
+  let payload: any;
+  try {
+    payload = JSON.parse(Buffer.from(payloadB64, 'base64url').toString('utf8'));
+  } catch {
+    return { valid: false, error: 'malformed' };
+  }
+
+  if (!payload || !payload.m || !payload.e || !payload.exp) {
+    return { valid: false, error: 'malformed' };
+  }
+
+  if (Date.now() > Number(payload.exp)) {
+    return { valid: false, error: 'expired' };
+  }
+
+  return {
+    valid: true,
+    payload: {
+      meetingId: String(payload.m),
+      email: String(payload.e),
+      meetingName: payload.n || '',
+      expiresAt: new Date(Number(payload.exp)).toISOString()
+    }
+  };
+}

--- a/src/lib/server/importInvitedMeeting.ts
+++ b/src/lib/server/importInvitedMeeting.ts
@@ -1,0 +1,87 @@
+/**
+ * Import an email-bound guest invitation into a freshly-registered account.
+ *
+ * Given the signed `invite` token that the meetings app put on the register
+ * link, verify it and — if the registering email matches the invited email —
+ * create a pending meeting participant (`pgishauserpend`) for the new user.
+ * This mirrors how `createNewMeeting` invites registered users, so the meeting
+ * shows up in the new user's pending-invitations list to approve.
+ *
+ * Best-effort: never throws. Registration must succeed even if import fails.
+ */
+
+import { env } from '$env/dynamic/private';
+import { qids } from '../../routes/api/send/qids.js';
+import { verifyInviteToken } from './guestInvite.js';
+
+function adminToken(): string {
+  let t = String(env.ADMINMONTHER ?? '').replace(/\s+/g, '');
+  if (t.startsWith('ADMINMONTHER=')) t = t.slice('ADMINMONTHER='.length);
+  return t;
+}
+
+export interface ImportResult {
+  imported: boolean;
+  reason?: 'no_token' | 'invalid' | 'expired' | 'email_mismatch' | 'error';
+  meetingId?: string;
+}
+
+/**
+ * @param token       the signed invite token (from `?invite=`)
+ * @param userId      the new user's id
+ * @param email       the new user's (registered) email
+ * @param fetchFn     the request-scoped fetch
+ */
+export async function importInvitedMeeting(
+  token: string | undefined | null,
+  userId: string,
+  email: string,
+  fetchFn: typeof globalThis.fetch
+): Promise<ImportResult> {
+  if (!token) return { imported: false, reason: 'no_token' };
+
+  const res = verifyInviteToken(token);
+  if (!res.valid || !res.payload) {
+    return {
+      imported: false,
+      reason: res.error === 'expired' ? 'expired' : 'invalid'
+    };
+  }
+
+  // The invite is bound to a specific email — only import if it matches the
+  // account that was actually created.
+  if (res.payload.email.toLowerCase() !== String(email).trim().toLowerCase()) {
+    return { imported: false, reason: 'email_mismatch' };
+  }
+
+  const meetingId = res.payload.meetingId;
+
+  try {
+    const endpoint = import.meta.env.VITE_URL + '/graphql';
+    const response = await fetchFn(endpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${adminToken()}`
+      },
+      body: JSON.stringify({
+        query: qids['19CreatePendMeeting'],
+        variables: { id: String(userId), pgishaId: String(meetingId) }
+      })
+    });
+
+    const data = await response.json();
+    if (data?.errors || !data?.data?.createPgishauserpend?.data?.id) {
+      console.error(
+        '[importInvitedMeeting] Strapi error:',
+        JSON.stringify(data?.errors)
+      );
+      return { imported: false, reason: 'error', meetingId };
+    }
+
+    return { imported: true, meetingId };
+  } catch (e) {
+    console.error('[importInvitedMeeting] failed:', e);
+    return { imported: false, reason: 'error', meetingId };
+  }
+}

--- a/src/routes/api/send/qids.js
+++ b/src/routes/api/send/qids.js
@@ -327,7 +327,53 @@ const qids_base = {
     }
   }
  }
-`, "18createNewMeeting": `mutation CreateNewMeeting( $outpot: String, $name: String,$publishedAt:DateTime) {
+`,
+
+  // ── Meeting participant selection (privacy-preserving) ─────────────────────
+  // Co-members: the users the current user shares at least one project with.
+  // Used to populate the "add participants" dropdown so it never exposes the
+  // whole user base — only people you already collaborate with.
+  '170getMyCoMembers': `query GetMyCoMembers($uid: ID!) {
+  usersPermissionsUser(id: $uid) {
+    data {
+      id
+      attributes {
+        username
+        projects_1s {
+          data {
+            id
+            attributes {
+              projectName
+              user_1s {
+                data {
+                  id
+                  attributes { username }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}`,
+
+  // Exact lookup used when inviting someone who is NOT a co-member: the inviter
+  // must know the person's full username or email. Matches are exact (eq), so
+  // this can't be used to enumerate/guess users. Returns minimal fields only.
+  '171findUserByExact': `query FindUserByExact($q: String!) {
+  usersPermissionsUsers(
+    filters: { or: [ { username: { eq: $q } }, { email: { eq: $q } } ] }
+    pagination: { limit: 1 }
+  ) {
+    data {
+      id
+      attributes { username }
+    }
+  }
+}`,
+
+  "18createNewMeeting": `mutation CreateNewMeeting( $outpot: String, $name: String,$publishedAt:DateTime) {
   createPgisha(data: 
     {name: $name, desc: $outpot,publishedAt:$publishedAt})
      {data{id}}

--- a/src/routes/hascama/+page.server.js
+++ b/src/routes/hascama/+page.server.js
@@ -1,0 +1,21 @@
+/**
+ * Capture an email-bound guest invitation token off the register link.
+ *
+ * The meetings app sends invited guests to `/hascama?invite=<signed-token>`.
+ * The onboarding UI is client-driven and hops through /signup, so we stash the
+ * token in a short-lived cookie here; the signup action consumes it after the
+ * account is created and imports the meeting (see importInvitedMeeting).
+ */
+export function load({ url, cookies }) {
+  const invite = url.searchParams.get('invite');
+  if (invite) {
+    cookies.set('invite_token', invite, {
+      path: '/',
+      httpOnly: true,
+      secure: import.meta.env.PROD,
+      sameSite: 'lax',
+      maxAge: 60 * 60 // 1 hour — long enough to finish signup
+    });
+  }
+  return {};
+}

--- a/src/routes/signup/+page.server.js
+++ b/src/routes/signup/+page.server.js
@@ -1,4 +1,5 @@
 import { redirect, fail } from '@sveltejs/kit';
+import { importInvitedMeeting } from '$lib/server/importInvitedMeeting.js';
 
 const baseUrl = import.meta.env.VITE_URL;
 
@@ -10,11 +11,15 @@ export async function load({ cookies }) {
 }
 
 export const actions = {
-  default: async ({ request, cookies }) => {
+  default: async ({ request, cookies, fetch }) => {
     const data = await request.formData();
-    const email = String(data.get('email') || '').trim().toLowerCase();
+    const email = String(data.get('email') || '')
+      .trim()
+      .toLowerCase();
     const password = String(data.get('password') || '');
-    const displayName = String(data.get('displayName') || cookies.get('un') || '').trim();
+    const displayName = String(
+      data.get('displayName') || cookies.get('un') || ''
+    ).trim();
 
     const fpval = cookies.get('fpval');
     const countryCookie = cookies.get('country') || '';
@@ -30,7 +35,9 @@ export const actions = {
     }
 
     if (password.length < 8 || !/[A-Z]/.test(password)) {
-      return fail(400, { error: 'הסיסמה חייבת להכיל לפחות 8 תווים ואות גדולה באנגלית' });
+      return fail(400, {
+        error: 'הסיסמה חייבת להכיל לפחות 8 תווים ואות גדולה באנגלית'
+      });
     }
 
     const username = displayName
@@ -52,8 +59,13 @@ export const actions = {
       if (!res.ok) {
         const err = await res.json();
         const msg = err?.error?.message || 'שגיאה ברישום';
-        if (msg.toLowerCase().includes('already taken') || msg.toLowerCase().includes('already exist')) {
-          return fail(400, { error: 'כתובת המייל כבר רשומה במערכת. נסו להתחבר.' });
+        if (
+          msg.toLowerCase().includes('already taken') ||
+          msg.toLowerCase().includes('already exist')
+        ) {
+          return fail(400, {
+            error: 'כתובת המייל כבר רשומה במערכת. נסו להתחבר.'
+          });
         }
         return fail(400, { error: msg });
       }
@@ -71,10 +83,34 @@ export const actions = {
 
       cookies.set('jwt', jwt, { ...cookieOptions, httpOnly: true });
       cookies.set('id', String(user.id), { ...cookieOptions, httpOnly: false });
-      cookies.set('un', user.name || displayName || user.username, { ...cookieOptions, httpOnly: false });
-      cookies.set('when', Date.now().toString(), { ...cookieOptions, httpOnly: false });
+      cookies.set('un', user.name || displayName || user.username, {
+        ...cookieOptions,
+        httpOnly: false
+      });
+      cookies.set('when', Date.now().toString(), {
+        ...cookieOptions,
+        httpOnly: false
+      });
       cookies.set('email', email, { ...cookieOptions, httpOnly: false });
       cookies.set('guidMe', 'again', { ...cookieOptions, httpOnly: false });
+
+      // If the user arrived from an email-bound meeting invitation
+      // (/hascama?invite=<token>), import that meeting into the new account.
+      // Best-effort: signup must not fail if the import does.
+      const inviteToken = cookies.get('invite_token');
+      if (inviteToken) {
+        try {
+          await importInvitedMeeting(
+            inviteToken,
+            String(user.id),
+            email,
+            fetch
+          );
+        } catch (err) {
+          console.error('[signup] invited-meeting import failed:', err);
+        }
+        cookies.delete('invite_token', { path: '/' });
+      }
 
       throw redirect(303, '/signup/check-email');
     } catch (err) {


### PR DESCRIPTION
Supports the meetings-app switching its participant picker away from the
"all users" query (17getUsers) to a privacy-preserving flow:

- 170getMyCoMembers: users the current user shares a project with
  (via projects_1s -> user_1s), to populate the picker dropdown.
- 171findUserByExact: exact username/email lookup (eq, limit 1) so people
  outside your projects can be invited only when you know their full
  username or email, without enabling enumeration.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KLXHnyrr9cxpW9XVkNkkwV