### PR TITLE
Fix /me tag panels bleeding into center content on mobile

### DIFF
--- a/src/lib/components/userPr/edit.svelte
+++ b/src/lib/components/userPr/edit.svelte
@@ -714,7 +714,7 @@ console.log("skillslist",skillslist);
     </h2>
     {#if data.length > 0}
       <div
-        class="flex sm:flex-row flex-wrap justify-center align-middle inner-scroll d cd p-2 mb-1"
+        class="flex flex-col sm:flex-row sm:flex-wrap justify-center items-center inner-scroll d cd p-2 mb-1"
       >
         {#each data as dat, i}
           <p class="m-0" style="text-shadow:none; white-space:none;">
@@ -768,7 +768,7 @@ console.log("skillslist",skillslist);
       </p>
       {#if data.length > 0}
         <div
-          class="  flex sm:flex-row flex-wrap justify-center align-middle d cd p-2 mb-1"
+          class="  flex flex-col sm:flex-row sm:flex-wrap justify-center items-center d cd p-2 mb-1"
         >
           {#each data as da, i (da.id)}
             <div
@@ -1047,6 +1047,12 @@ console.log("skillslist",skillslist);
     max-height: 20vh;
     width: 100%;
     overflow-y: auto;
+    overflow-x: hidden;
+  }
+  .inner-scroll :global(span) {
+    max-width: 100%;
+    white-space: normal;
+    word-break: break-word;
   }
   .th {
     margin-top: 0.2em;

--- a/src/routes/(reg)/me/+page.svelte
+++ b/src/routes/(reg)/me/+page.svelte
@@ -1117,6 +1117,7 @@
   .pro {
     max-height: 15vh;
     overflow-y: scroll;
+    overflow-x: hidden;
   }
 
   :global([data-svelte-dialog-overlay].content) {
@@ -1173,6 +1174,8 @@
     display: flex;
     flex-direction: row;
     flex-wrap: wrap;
+    max-width: 100%;
+    word-break: break-word;
   }
   .cont > span {
     display: none;
@@ -1210,6 +1213,7 @@
     .pro {
       max-height: 15vh;
       overflow-y: scroll;
+      overflow-x: hidden;
     }
     .another {
       max-height: 25vh;
@@ -1524,6 +1528,7 @@
     max-height: 20vh;
     width: 100%;
     overflow-y: auto;
+    overflow-x: hidden;
   }
 
   .cot {


### PR DESCRIPTION
The skill/role/resource/value/workway tag lists (edit.svelte) and the
projects list (me/+page.svelte) used overflow:visible row-wrap
containers, letting long pills spill sideways out of their narrow
mobile column and overlap the centered offerings/stats bar. Stack tags
vertically on mobile (row+wrap stays from sm: up) and clip horizontal
overflow on the scroll containers as a hard guard against any residual
bleed.